### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ make build
 
 ### Option 3
 ```bash
-go install github.com/owenHochwald/Volt/cmd/volt@latest
+go install github.com/owenHochwald/volt/cmd/volt@latest
 ```
 
 ## Quick Start


### PR DESCRIPTION
Fix go installation path.
With current version you will get error:
```
go: github.com/owenHochwald/Volt/cmd/volt@latest: version constraints conflict:
	github.com/owenHochwald/Volt@v0.1.1: parsing go.mod:
	module declares its path as: github.com/owenHochwald/volt
	       but was required as: github.com/owenHochwald/Volt
```