### PR TITLE
Fix load-test execution and statistics correctness

### DIFF
--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/owenHochwald/Volt/internal/http"
 	"github.com/owenHochwald/Volt/internal/ui"
@@ -91,7 +92,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// start load test in background
 		go func() {
-			msg.Config.Run(updates)
+			msg.Config.Run(context.Background(), updates)
 		}()
 
 		m.responsePane.ClearLoadTestStats()

--- a/internal/cli/bench.go
+++ b/internal/cli/bench.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/signal"
@@ -24,50 +25,34 @@ func RunBench(config *BenchConfig) error {
 		Body:    config.Body,
 	}
 
-	// Calculate total requests if duration-based
-	totalRequests := config.TotalRequests
-	if totalRequests == 0 {
-		estimatedReqsPerWorkerPerSec := 1000
-		totalRequests = config.Concurrency * int(config.Duration.Seconds()) * estimatedReqsPerWorkerPerSec
-
-		if totalRequests < 1 {
-			totalRequests = 1
-		}
-	}
-
 	jobConfig := &http.JobConfig{
-		Request:       req,
-		Concurrency:   config.Concurrency,
-		TotalRequests: totalRequests,
-		Timeout:       config.Timeout,
-		QPS:           float64(config.RateLimit),
-		StreamUpdates: false,
+		Request:          req,
+		Concurrency:      config.Concurrency,
+		TotalRequests:    config.TotalRequests,
+		Duration:         config.Duration,
+		Timeout:          config.Timeout,
+		QPS:              float64(config.RateLimit),
+		DisableKeepAlive: !config.KeepAlive,
+		StreamUpdates:    false,
 	}
 
 	updates := make(chan *http.LoadTestStats, 1000)
 
-	// Handle Ctrl+C gracefully
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
-
-	go jobConfig.Run(updates)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	go jobConfig.Run(ctx, updates)
 
 	var finalStats *http.LoadTestStats
-	for {
-		select {
-		case stats, ok := <-updates:
-			if !ok {
-				// Channel closed, test complete
-				return FormatOutput(finalStats, config)
-			}
+	for stats := range updates {
+		if stats != nil {
 			finalStats = stats
-
-		case <-sigCh:
-			fmt.Fprintln(os.Stderr, "\nTest interrupted by user")
-			if finalStats != nil {
-				return FormatOutput(finalStats, config)
-			}
-			return nil
 		}
 	}
+	if ctx.Err() != nil {
+		fmt.Fprintln(os.Stderr, "\nTest interrupted by user")
+	}
+	if finalStats == nil {
+		return nil
+	}
+	return FormatOutput(finalStats, config)
 }

--- a/internal/cli/flags_test.go
+++ b/internal/cli/flags_test.go
@@ -25,6 +25,18 @@ func TestParseBenchFlags(t *testing.T) {
 				if c.Concurrency != 50 {
 					t.Errorf("Concurrency = %d, want 50", c.Concurrency)
 				}
+				if !c.KeepAlive {
+					t.Error("KeepAlive should default to true")
+				}
+			},
+		},
+		{
+			name: "disable keepalive",
+			args: []string{"-url", "http://example.com", "-no-keepalive"},
+			check: func(t *testing.T, c *BenchConfig) {
+				if c.KeepAlive {
+					t.Error("KeepAlive should be false")
+				}
 			},
 		},
 		{

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -34,8 +35,14 @@ func FormatOutput(stats *http.LoadTestStats, config *BenchConfig) error {
 // formatTable produces human-readable table output
 func formatTable(stats *http.LoadTestStats) string {
 	duration := stats.EndTime.Sub(stats.StartTime)
-	successRate := float64(stats.CompletedRequests-stats.FailedRequests) / float64(stats.CompletedRequests) * 100
-	rps := float64(stats.CompletedRequests) / duration.Seconds()
+	successRate := 0.0
+	if stats.CompletedRequests > 0 {
+		successRate = float64(stats.CompletedRequests-stats.FailedRequests) / float64(stats.CompletedRequests) * 100
+	}
+	rps := 0.0
+	if duration > 0 {
+		rps = float64(stats.CompletedRequests) / duration.Seconds()
+	}
 
 	var out strings.Builder
 
@@ -53,23 +60,41 @@ func formatTable(stats *http.LoadTestStats) string {
 
 	// Calculate data transfer rate
 	totalBytes := stats.BytesSent + stats.BytesRecv
-	dataSec := float64(totalBytes) / duration.Seconds() / (1024 * 1024) // MB/s
+	dataSec := 0.0
+	if duration > 0 {
+		dataSec = float64(totalBytes) / duration.Seconds() / (1024 * 1024) // MB/s
+	}
 	out.WriteString(fmt.Sprintf("  Data/sec:     %.2f MB\n\n", dataSec))
 
 	out.WriteString("Latency:\n")
 	out.WriteString(fmt.Sprintf("  Min:          %s\n", formatDuration(stats.MinDuration)))
 
-	avgDuration := stats.TotalDuration / time.Duration(stats.CompletedRequests)
-	out.WriteString(fmt.Sprintf("  Mean:         %s\n", formatDuration(avgDuration)))
+	out.WriteString(fmt.Sprintf("  Mean:         %s\n", formatDuration(stats.MeanDuration())))
 	out.WriteString(fmt.Sprintf("  p50:          %s\n", formatDuration(stats.Percentiles.Percentile(50))))
 	out.WriteString(fmt.Sprintf("  p95:          %s\n", formatDuration(stats.Percentiles.Percentile(95))))
 	out.WriteString(fmt.Sprintf("  p99:          %s\n", formatDuration(stats.Percentiles.Percentile(99))))
 	out.WriteString(fmt.Sprintf("  Max:          %s\n\n", formatDuration(stats.MaxDuration)))
 
-	if len(stats.Errors) > 0 {
+	if len(stats.StatusCodes) > 0 {
 		out.WriteString("Status Codes:\n")
-		for code, count := range stats.Errors {
-			out.WriteString(fmt.Sprintf("  %s:          %s\n", code, formatNumber(int(count))))
+		statuses := make([]int, 0, len(stats.StatusCodes))
+		for status := range stats.StatusCodes {
+			statuses = append(statuses, status)
+		}
+		sort.Ints(statuses)
+		for _, status := range statuses {
+			out.WriteString(fmt.Sprintf("  %d:          %s\n", status, formatNumber(int(stats.StatusCodes[status]))))
+		}
+	}
+	if len(stats.Errors) > 0 {
+		out.WriteString("Errors:\n")
+		errorClasses := make([]string, 0, len(stats.Errors))
+		for class := range stats.Errors {
+			errorClasses = append(errorClasses, class)
+		}
+		sort.Strings(errorClasses)
+		for _, class := range errorClasses {
+			out.WriteString(fmt.Sprintf("  %s:          %s\n", class, formatNumber(int(stats.Errors[class]))))
 		}
 	}
 
@@ -79,26 +104,39 @@ func formatTable(stats *http.LoadTestStats) string {
 // formatJSON produces machine-readable JSON output
 func formatJSON(stats *http.LoadTestStats) string {
 	duration := stats.EndTime.Sub(stats.StartTime)
+	successRate := 0.0
+	throughput := 0.0
+	if stats.CompletedRequests > 0 {
+		successRate = float64(stats.CompletedRequests-stats.FailedRequests) / float64(stats.CompletedRequests)
+	}
+	if duration > 0 {
+		throughput = float64(stats.CompletedRequests) / duration.Seconds()
+	}
 
 	result := map[string]interface{}{
 		"summary": map[string]interface{}{
 			"totalRequests":     stats.TotalRequests,
 			"completedRequests": stats.CompletedRequests,
 			"failedRequests":    stats.FailedRequests,
-			"successRate":       float64(stats.CompletedRequests-stats.FailedRequests) / float64(stats.CompletedRequests),
-			"throughput":        float64(stats.CompletedRequests) / duration.Seconds(),
-			"durationMs":        duration.Milliseconds(),
+			"successRate":       successRate,
+			"throughput":        throughput,
+			"durationMs":        durationMilliseconds(duration),
 		},
 		"latency": map[string]interface{}{
-			"minMs": stats.MinDuration.Milliseconds(),
-			"avgMs": (stats.TotalDuration / time.Duration(stats.CompletedRequests)).Milliseconds(),
-			"p50Ms": stats.Percentiles.Percentile(50).Milliseconds(),
-			"p90Ms": stats.Percentiles.Percentile(90).Milliseconds(),
-			"p95Ms": stats.Percentiles.Percentile(95).Milliseconds(),
-			"p99Ms": stats.Percentiles.Percentile(99).Milliseconds(),
-			"maxMs": stats.MaxDuration.Milliseconds(),
+			"minMs": durationMilliseconds(stats.MinDuration),
+			"avgMs": durationMilliseconds(stats.MeanDuration()),
+			"p50Ms": durationMilliseconds(stats.Percentiles.Percentile(50)),
+			"p90Ms": durationMilliseconds(stats.Percentiles.Percentile(90)),
+			"p95Ms": durationMilliseconds(stats.Percentiles.Percentile(95)),
+			"p99Ms": durationMilliseconds(stats.Percentiles.Percentile(99)),
+			"maxMs": durationMilliseconds(stats.MaxDuration),
 		},
-		"errors": stats.Errors,
+		"errors":      stats.Errors,
+		"statusCodes": stats.StatusCodes,
+		"transfer": map[string]interface{}{
+			"bytesSent":     stats.BytesSent,
+			"bytesReceived": stats.BytesRecv,
+		},
 	}
 
 	data, _ := json.MarshalIndent(result, "", "  ")
@@ -108,12 +146,19 @@ func formatJSON(stats *http.LoadTestStats) string {
 // formatQuiet produces one-line summary
 func formatQuiet(stats *http.LoadTestStats) string {
 	duration := stats.EndTime.Sub(stats.StartTime)
-	rps := float64(stats.CompletedRequests) / duration.Seconds()
+	rps := 0.0
+	if duration > 0 {
+		rps = float64(stats.CompletedRequests) / duration.Seconds()
+	}
 	p50 := stats.Percentiles.Percentile(50)
 	p99 := stats.Percentiles.Percentile(99)
 
 	return fmt.Sprintf("Requests: %d | RPS: %.2f | p50: %s | p99: %s | Failed: %d\n",
 		stats.CompletedRequests, rps, formatDuration(p50), formatDuration(p99), stats.FailedRequests)
+}
+
+func durationMilliseconds(d time.Duration) float64 {
+	return float64(d.Nanoseconds()) / float64(time.Millisecond)
 }
 
 func formatNumber(n int) string {

--- a/internal/cli/validator.go
+++ b/internal/cli/validator.go
@@ -31,11 +31,20 @@ func (c *BenchConfig) Validate() error {
 		return errors.New("concurrency must be > 0")
 	}
 
-	// Duration and TotalRequests are mutually exclusive
-	if c.Duration == 0 && c.TotalRequests == 0 {
+	if c.Duration < 0 {
+		return errors.New("duration must be >= 0")
+	}
+	if c.TotalRequests < 0 {
+		return errors.New("total requests must be >= 0")
+	}
+
+	// Exactly one positive execution bound is required.
+	durationMode := c.Duration > 0
+	requestCountMode := c.TotalRequests > 0
+	if !durationMode && !requestCountMode {
 		return errors.New("must specify either -d (duration) or -n (total requests)")
 	}
-	if c.Duration > 0 && c.TotalRequests > 0 {
+	if durationMode && requestCountMode {
 		return errors.New("-d and -n are mutually exclusive")
 	}
 

--- a/internal/cli/validator_test.go
+++ b/internal/cli/validator_test.go
@@ -112,6 +112,29 @@ func TestBenchConfig_Validate(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "negative duration",
+			config: &BenchConfig{
+				URL:         "http://example.com",
+				Method:      "GET",
+				Concurrency: 10,
+				Duration:    -time.Second,
+				Timeout:     30 * time.Second,
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative total requests",
+			config: &BenchConfig{
+				URL:           "http://example.com",
+				Method:        "GET",
+				Concurrency:   10,
+				Duration:      10 * time.Second,
+				TotalRequests: -1,
+				Timeout:       30 * time.Second,
+			},
+			wantErr: true,
+		},
+		{
 			name: "zero timeout",
 			config: &BenchConfig{
 				URL:         "http://example.com",

--- a/internal/http/fastclient.go
+++ b/internal/http/fastclient.go
@@ -1,6 +1,9 @@
 package http
 
 import (
+	"context"
+	"net"
+	"sync"
 	"time"
 
 	"github.com/valyala/fasthttp"
@@ -19,28 +22,51 @@ type FastRequest struct {
 }
 
 type FastClient struct {
-	client  *fasthttp.Client
-	timeout time.Duration
+	client    *fasthttp.Client
+	timeout   time.Duration
+	keepAlive bool
+	conns     connectionTracker
 }
 
 func NewFastClient(timeout time.Duration, s *JobConfig) *FastClient {
-	return &FastClient{
-		timeout: timeout,
+	f := &FastClient{
+		timeout:   timeout,
+		keepAlive: !s.DisableKeepAlive,
 		client: &fasthttp.Client{
-			MaxConnsPerHost:     max(500, s.Concurrency),
-			MaxIdleConnDuration: 10 * time.Second,
-			ReadTimeout:         s.Timeout,
-			WriteTimeout:        s.Timeout,
-			MaxConnDuration:     0,
+			MaxConnsPerHost:           max(500, s.Concurrency),
+			MaxIdleConnDuration:       10 * time.Second,
+			ReadTimeout:               s.Timeout,
+			WriteTimeout:              s.Timeout,
+			MaxConnDuration:           0,
+			MaxIdemponentCallAttempts: 1,
 		},
 	}
+	f.client.DialTimeout = f.dialTimeout
+	return f
+}
+
+func (f *FastClient) dialTimeout(addr string, timeout time.Duration) (net.Conn, error) {
+	conn, err := fasthttp.DialTimeout(addr, timeout)
+	if err != nil {
+		return nil, err
+	}
+	return f.conns.track(conn)
+}
+
+// Cancel interrupts active requests by closing this run's connections.
+func (f *FastClient) Cancel() {
+	f.conns.cancel()
+}
+
+func (f *FastClient) CloseIdleConnections() {
+	f.client.CloseIdleConnections()
 }
 
 func (f *FastClient) Do(
 	fr *FastRequest,
 	req *fasthttp.Request,
 	res *fasthttp.Response,
-) (status int, contentLen int64, err error) {
+) (status int, bytesSent int64, bytesRecv int64, err error) {
 	req.Reset()
 	res.Reset()
 
@@ -54,11 +80,67 @@ func (f *FastClient) Do(
 	if fr.Body != nil {
 		req.SetBodyRaw(fr.Body)
 	}
+	if !f.keepAlive {
+		req.Header.SetConnectionClose()
+	}
 
 	err = f.client.DoTimeout(req, res, f.timeout)
 	if err != nil {
-		return 0, 0, err
+		return 0, int64(len(fr.Body)), int64(len(res.Body())), err
 	}
 
-	return res.StatusCode(), int64(res.Header.ContentLength()), nil
+	return res.StatusCode(), int64(len(fr.Body)), int64(len(res.Body())), nil
+}
+
+type connectionTracker struct {
+	mu       sync.Mutex
+	conns    map[net.Conn]struct{}
+	canceled bool
+}
+
+func (t *connectionTracker) track(conn net.Conn) (net.Conn, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.canceled {
+		_ = conn.Close()
+		return nil, context.Canceled
+	}
+	if t.conns == nil {
+		t.conns = make(map[net.Conn]struct{})
+	}
+	t.conns[conn] = struct{}{}
+	return &trackedConn{Conn: conn, tracker: t}, nil
+}
+
+func (t *connectionTracker) remove(conn net.Conn) {
+	t.mu.Lock()
+	delete(t.conns, conn)
+	t.mu.Unlock()
+}
+
+func (t *connectionTracker) cancel() {
+	t.mu.Lock()
+	t.canceled = true
+	conns := make([]net.Conn, 0, len(t.conns))
+	for conn := range t.conns {
+		conns = append(conns, conn)
+	}
+	clear(t.conns)
+	t.mu.Unlock()
+
+	for _, conn := range conns {
+		_ = conn.Close()
+	}
+}
+
+type trackedConn struct {
+	net.Conn
+	tracker *connectionTracker
+	once    sync.Once
+}
+
+func (c *trackedConn) Close() error {
+	err := c.Conn.Close()
+	c.once.Do(func() { c.tracker.remove(c.Conn) })
+	return err
 }

--- a/internal/http/requester.go
+++ b/internal/http/requester.go
@@ -158,7 +158,7 @@ type runState struct {
 	limiter *globalRateLimiter
 }
 
-// globalRateLimiter assigns request start times from one process-wide schedule
+// globalRateLimiter assigns request start times from one run-wide schedule
 // shared by every worker. It deliberately allows an initial request
 // immediately, followed by evenly spaced starts (burst size one).
 type globalRateLimiter struct {
@@ -228,6 +228,17 @@ func (s *JobConfig) Run(ctx context.Context, updates chan<- *LoadTestStats) {
 	}
 
 	start := time.Now()
+	if s.Duration <= 0 && s.TotalRequests <= 0 {
+		stats := NewLoadTestStats(0)
+		stats.StartTime = start
+		stats.EndTime = time.Now()
+		stats.MinDuration = 0
+		snapshot := stats.GetSnapshot()
+		updates <- &snapshot
+		close(updates)
+		return
+	}
+
 	runCtx := ctx
 	cancel := func() {}
 	if s.Duration > 0 {

--- a/internal/http/requester.go
+++ b/internal/http/requester.go
@@ -5,24 +5,71 @@
 package http
 
 import (
+	"context"
+	"errors"
 	"math"
-	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/influxdata/tdigest"
 	"github.com/valyala/fasthttp"
 )
 
-// largest size of the buffer for the result channel
-const maxResult = 1_000_000
+const statsBatchSize = 256
 
-// PercentileCalculator data structure for streaming percentile calculations
+// PercentileCalculator calculates quantiles from every observed request
+// latency. Values are stored in nanoseconds so sub-millisecond observations
+// retain their precision.
 type PercentileCalculator struct {
+	mu     sync.Mutex
 	digest *tdigest.TDigest
 }
 
-// LoadTestStats holds aggregated stats about the load test
+func newPercentileCalculator() *PercentileCalculator {
+	return &PercentileCalculator{digest: tdigest.NewWithCompression(100)}
+}
+
+func (p *PercentileCalculator) add(duration time.Duration) {
+	p.mu.Lock()
+	p.digest.Add(float64(duration.Nanoseconds()), 1)
+	p.mu.Unlock()
+}
+
+func (p *PercentileCalculator) addBatch(durations []time.Duration) {
+	p.mu.Lock()
+	for _, duration := range durations {
+		p.digest.Add(float64(duration.Nanoseconds()), 1)
+	}
+	p.mu.Unlock()
+}
+
+func (p *PercentileCalculator) clone() *PercentileCalculator {
+	clone := newPercentileCalculator()
+	p.mu.Lock()
+	clone.digest.AddCentroidList(p.digest.Centroids())
+	p.mu.Unlock()
+	return clone
+}
+
+// Percentile returns the requested percentile while preserving nanosecond
+// precision.
+func (p *PercentileCalculator) Percentile(percentile float64) time.Duration {
+	if p == nil {
+		return 0
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.digest.Count() == 0 {
+		return 0
+	}
+
+	ns := p.digest.Quantile(percentile / 100.0)
+	return time.Duration(math.Round(ns))
+}
+
+// LoadTestStats holds aggregated stats about the load test.
 type LoadTestStats struct {
 	StartTime         time.Time
 	EndTime           time.Time
@@ -30,103 +77,203 @@ type LoadTestStats struct {
 	CompletedRequests int
 	FailedRequests    int
 
-	// time tracking
 	MinDuration   time.Duration
 	MaxDuration   time.Duration
 	TotalDuration time.Duration
 
-	// streaming percentile calculations
 	Percentiles *PercentileCalculator
 
-	// network stats
+	// BytesSent and BytesRecv are application payload bytes. They intentionally
+	// exclude transport framing and HTTP headers.
 	BytesSent int64
 	BytesRecv int64
 
-	// error tracking
-	Errors map[string]int64 // error code -> count
+	// Errors contains failure classes such as http_4xx, http_5xx, timeout, and
+	// transport. StatusCodes contains every received HTTP status.
+	Errors      map[string]int64
+	StatusCodes map[int]int64
 
-	// system metrics
-	CPUUsage    float64 // percentage
-	MemoryUsage uint64  // bytes
+	CPUUsage    float64
+	MemoryUsage uint64
 
-	mu sync.RWMutex // protects above fields from concurrent access
+	mu sync.RWMutex
 }
 
-// workerStats holds per-worker local statistics (no mutex needed)
-type workerStats struct {
-	requests uint64 // total requests by this worker
-	failures uint64 // failed requests
-
-	// Sampled latency tracking (1/256 requests)
-	sampledCount uint64
-	sampledMin   uint64 // nanoseconds
-	sampledMax   uint64 // nanoseconds
-	sampledTotal uint64 // sum for average calculation
-
-	errorCodes map[int]uint64
+// MeanDuration returns the mean latency across all completed attempts.
+func (s *LoadTestStats) MeanDuration() time.Duration {
+	if s == nil {
+		return 0
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.CompletedRequests == 0 {
+		return 0
+	}
+	return time.Duration(int64(s.TotalDuration) / int64(s.CompletedRequests))
 }
 
-// workerStatsMsg is sent from workers to aggregator
-type workerStatsMsg struct {
-	workerID int
-	stats    workerStats
+// requestBatch is pooled and passed by pointer so the hot path does not
+// allocate for every request or copy latency arrays through the channel.
+type requestBatch struct {
+	count         int
+	failures      int
+	timeoutErrs   int
+	transportErrs int
+	canceledErrs  int
+	bytesSent     int64
+	bytesRecv     int64
+	total         time.Duration
+	min           time.Duration
+	max           time.Duration
+	latencies     [statsBatchSize]time.Duration
+	statuses      [statsBatchSize]uint16
+}
+
+func (b *requestBatch) reset() {
+	*b = requestBatch{}
 }
 
 type JobConfig struct {
-	// Request config
-	Request     *Request // base request to send
+	Request     *Request
 	FastRequest *FastRequest
 
-	// Load parameters
-	Concurrency   int           // number of concurrent requests
-	TotalRequests int           // total requests to send
-	RateLimit     int           // max requests per second
-	Timeout       time.Duration // time per request
-	QPS           float64       // rate limit for queries per second
-	StreamUpdates bool          // if false, only send final result (for CLI mode)
-
-	// Internal state
-	client        *FastClient
-	workerStatsCh chan workerStatsMsg
-	stopCh        chan struct{}
-	start         time.Time
-	once          sync.Once
-	stats         *LoadTestStats
+	Concurrency      int
+	TotalRequests    int
+	Duration         time.Duration
+	RateLimit        int
+	Timeout          time.Duration
+	QPS              float64
+	DisableKeepAlive bool
+	StreamUpdates    bool
 }
 
-// NewLoadTestStats creates a new LoadTestStats instance
+type runState struct {
+	config  *JobConfig
+	client  *FastClient
+	request *FastRequest
+	stats   *LoadTestStats
+	batches chan *requestBatch
+	pool    sync.Pool
+	next    atomic.Uint64
+	limiter *globalRateLimiter
+}
+
+// globalRateLimiter assigns request start times from one process-wide schedule
+// shared by every worker. It deliberately allows an initial request
+// immediately, followed by evenly spaced starts (burst size one).
+type globalRateLimiter struct {
+	mu       sync.Mutex
+	next     time.Time
+	interval time.Duration
+}
+
+func newGlobalRateLimiter(qps float64, start time.Time) *globalRateLimiter {
+	if qps <= 0 {
+		return nil
+	}
+	interval := time.Duration(float64(time.Second) / qps)
+	if interval < time.Nanosecond {
+		interval = time.Nanosecond
+	}
+	return &globalRateLimiter{next: start, interval: interval}
+}
+
+func (l *globalRateLimiter) wait(ctx context.Context) bool {
+	if l == nil {
+		return true
+	}
+
+	l.mu.Lock()
+	now := time.Now()
+	scheduled := l.next
+	if scheduled.Before(now) {
+		scheduled = now
+	}
+	l.next = scheduled.Add(l.interval)
+	l.mu.Unlock()
+
+	delay := time.Until(scheduled)
+	if delay <= 0 {
+		return ctx.Err() == nil
+	}
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return ctx.Err() == nil
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// NewLoadTestStats creates a new LoadTestStats instance.
 func NewLoadTestStats(totalRequests int) *LoadTestStats {
 	return &LoadTestStats{
 		StartTime:     time.Now(),
 		TotalRequests: totalRequests,
 		MinDuration:   time.Duration(math.MaxInt64),
-		Percentiles: &PercentileCalculator{
-			digest: tdigest.NewWithCompression(100),
-		},
-		Errors: make(map[string]int64),
+		Percentiles:   newPercentileCalculator(),
+		Errors:        make(map[string]int64),
+		StatusCodes:   make(map[int]int64),
 	}
 }
 
-// Run makes all the requests and streams results
-func (s *JobConfig) Run(updates chan<- *LoadTestStats) {
-	s.start = time.Now()
-	s.stats = NewLoadTestStats(s.TotalRequests)
-	s.FastRequest = compileRequest(s.Request)
-	s.client = NewFastClient(s.Timeout, s)
+// Run executes the job until its request count is reached, its configured
+// duration expires, or ctx is cancelled. The final exact snapshot is always
+// delivered before updates is closed.
+func (s *JobConfig) Run(ctx context.Context, updates chan<- *LoadTestStats) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
-	// aggregation channel (buffered for batch flushes)
-	s.workerStatsCh = make(chan workerStatsMsg, s.Concurrency*4)
+	start := time.Now()
+	runCtx := ctx
+	cancel := func() {}
+	if s.Duration > 0 {
+		runCtx, cancel = context.WithDeadline(ctx, start.Add(s.Duration))
+	}
+	defer cancel()
 
-	s.stopCh = make(chan struct{}, s.Concurrency)
+	concurrency := s.Concurrency
+	if concurrency < 1 {
+		concurrency = 1
+	}
 
-	// Aggregate in background
-	go s.aggregateStats(updates)
+	stats := NewLoadTestStats(s.TotalRequests)
+	stats.StartTime = start
+	state := &runState{
+		config:  s,
+		client:  NewFastClient(s.Timeout, s),
+		request: compileRequest(s.Request),
+		stats:   stats,
+		batches: make(chan *requestBatch, concurrency*4),
+		limiter: newGlobalRateLimiter(s.QPS, start),
+	}
+	state.pool.New = func() any { return new(requestBatch) }
 
-	// Run workers
-	s.runWorkers()
+	aggregateDone := make(chan struct{})
+	go state.aggregateStats(updates, aggregateDone)
 
-	// Signal completion
-	close(s.workerStatsCh)
+	cancelWatcherDone := make(chan struct{})
+	go func() {
+		select {
+		case <-runCtx.Done():
+			state.client.Cancel()
+		case <-cancelWatcherDone:
+		}
+	}()
+
+	var workers sync.WaitGroup
+	workers.Add(concurrency)
+	for workerID := 0; workerID < concurrency; workerID++ {
+		go state.runWorker(runCtx, &workers)
+	}
+	workers.Wait()
+	close(cancelWatcherDone)
+	state.client.CloseIdleConnections()
+	close(state.batches)
+	<-aggregateDone
 }
 
 func compileRequest(req *Request) *FastRequest {
@@ -142,19 +289,13 @@ func compileRequest(req *Request) *FastRequest {
 			Value: []byte(v),
 		})
 	}
-
 	if len(req.Body) > 0 {
 		fastReq.Body = []byte(req.Body)
 	}
-
 	return fastReq
 }
 
-func (p *PercentileCalculator) Percentile(percentile float64) time.Duration {
-	ms := p.digest.Quantile(percentile / 100.0)
-	return time.Duration(ms) * time.Millisecond
-}
-
+// GetSnapshot returns an immutable copy suitable for another goroutine.
 func (s *LoadTestStats) GetSnapshot() LoadTestStats {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -162,6 +303,10 @@ func (s *LoadTestStats) GetSnapshot() LoadTestStats {
 	errorsCopy := make(map[string]int64, len(s.Errors))
 	for k, v := range s.Errors {
 		errorsCopy[k] = v
+	}
+	statusCopy := make(map[int]int64, len(s.StatusCodes))
+	for k, v := range s.StatusCodes {
+		statusCopy[k] = v
 	}
 
 	return LoadTestStats{
@@ -173,184 +318,184 @@ func (s *LoadTestStats) GetSnapshot() LoadTestStats {
 		MinDuration:       s.MinDuration,
 		MaxDuration:       s.MaxDuration,
 		TotalDuration:     s.TotalDuration,
-		Percentiles:       s.Percentiles, // can share, it's thread safe
+		Percentiles:       s.Percentiles.clone(),
 		BytesSent:         s.BytesSent,
 		BytesRecv:         s.BytesRecv,
 		Errors:            errorsCopy,
+		StatusCodes:       statusCopy,
 		CPUUsage:          s.CPUUsage,
 		MemoryUsage:       s.MemoryUsage,
 	}
 }
 
-func (s *JobConfig) runWorker(workerID int, wg *sync.WaitGroup) {
+func (r *runState) runWorker(ctx context.Context, wg *sync.WaitGroup) {
 	defer wg.Done()
 
-	// Worker owns these for its ENTIRE lifetime
 	req := &fasthttp.Request{}
 	res := &fasthttp.Response{}
+	batch := r.acquireBatch()
 
-	// Local stats
-	var stats workerStats
-	stats.errorCodes = make(map[int]uint64, 8)
-
-	// QPS throttling setup
-	var qpsTicker *time.Ticker
-	var throttle <-chan time.Time
-	if s.QPS > 0 {
-		qpsTicker = time.NewTicker(time.Duration(1e6/s.QPS) * time.Microsecond)
-		defer qpsTicker.Stop()
-		throttle = qpsTicker.C
-	}
-
-	requestsPerWorker := s.TotalRequests / s.Concurrency
-	remainder := s.TotalRequests % s.Concurrency
-
-	// First 'remainder' workers get one extra request
-	if workerID < remainder {
-		requestsPerWorker++
-	}
-
-	for i := 0; i < requestsPerWorker; i++ {
-		// QPS throttling
-		if s.QPS > 0 {
-			<-throttle
+	for {
+		if ctx.Err() != nil {
+			break
 		}
-
-		// Check for stop signal
-		select {
-		case <-s.stopCh:
-			s.flushWorkerStats(workerID, &stats)
-			return
-		default:
-		}
-
-		// Latency sampling: 1 out of every 256 requests (cheap bitwise check)
-		sample := (i & 0xFF) == 0
-
-		var start time.Time
-		if sample {
-			start = time.Now()
-		}
-
-		status, _, err := s.client.Do(s.FastRequest, req, res)
-
-		if sample {
-			elapsed := uint64(time.Since(start).Nanoseconds())
-			stats.sampledCount++
-
-			if stats.sampledMin == 0 || elapsed < stats.sampledMin {
-				stats.sampledMin = elapsed
+		if r.config.TotalRequests > 0 {
+			requestNumber := r.next.Add(1)
+			if requestNumber > uint64(r.config.TotalRequests) {
+				break
 			}
-			if elapsed > stats.sampledMax {
-				stats.sampledMax = elapsed
-			}
-			stats.sampledTotal += elapsed
+		}
+		if !r.limiter.wait(ctx) {
+			break
 		}
 
-		stats.requests++
+		start := time.Now()
+		status, bytesSent, bytesRecv, err := r.client.Do(r.request, req, res)
+		elapsed := time.Since(start)
+
+		i := batch.count
+		batch.latencies[i] = elapsed
+		if status > 0 {
+			batch.statuses[i] = uint16(status)
+		}
+		batch.count++
+		batch.total += elapsed
+		batch.bytesSent += bytesSent
+		batch.bytesRecv += bytesRecv
+		if batch.min == 0 || elapsed < batch.min {
+			batch.min = elapsed
+		}
+		if elapsed > batch.max {
+			batch.max = elapsed
+		}
+
 		if err != nil {
-			stats.failures++
-			if status > 0 {
-				stats.errorCodes[status]++
+			batch.failures++
+			if ctx.Err() != nil {
+				batch.canceledErrs++
+			} else if isTimeoutError(err) {
+				batch.timeoutErrs++
+			} else {
+				batch.transportErrs++
 			}
+		} else if status >= 400 {
+			batch.failures++
 		}
 
-		// Flush every 256 requests
-		if (i&0xFF) == 0 && i > 0 {
-			s.flushWorkerStats(workerID, &stats)
-			for k := range stats.errorCodes {
-				delete(stats.errorCodes, k)
-			}
-			stats.requests = 0
-			stats.failures = 0
-			stats.sampledCount = 0
-			stats.sampledMin = 0
-			stats.sampledMax = 0
-			stats.sampledTotal = 0
+		if batch.count == statsBatchSize {
+			r.batches <- batch
+			batch = r.acquireBatch()
 		}
 	}
 
-	s.flushWorkerStats(workerID, &stats)
-}
-
-// flushWorkerStats sends local worker stats to aggregator (non-blocking)
-func (s *JobConfig) flushWorkerStats(workerID int, stats *workerStats) {
-	// Drop if aggregator is behind
-	select {
-	case s.workerStatsCh <- workerStatsMsg{workerID: workerID, stats: *stats}:
-	default:
-		// Skip this flush if aggregator channel is full
+	if batch.count > 0 {
+		r.batches <- batch
+	} else {
+		r.releaseBatch(batch)
 	}
 }
 
-func (s *JobConfig) aggregateStats(updates chan<- *LoadTestStats) {
+func isTimeoutError(err error) bool {
+	if errors.Is(err, fasthttp.ErrTimeout) {
+		return true
+	}
+	type timeout interface{ Timeout() bool }
+	var timeoutErr timeout
+	return errors.As(err, &timeoutErr) && timeoutErr.Timeout()
+}
+
+func (r *runState) acquireBatch() *requestBatch {
+	batch := r.pool.Get().(*requestBatch)
+	batch.reset()
+	return batch
+}
+
+func (r *runState) releaseBatch(batch *requestBatch) {
+	batch.reset()
+	r.pool.Put(batch)
+}
+
+func (r *runState) aggregateStats(updates chan<- *LoadTestStats, done chan<- struct{}) {
+	defer close(done)
+	defer close(updates)
+
 	var ticker *time.Ticker
 	var tickerCh <-chan time.Time
-
-	if s.StreamUpdates {
+	if r.config.StreamUpdates {
 		ticker = time.NewTicker(300 * time.Millisecond)
 		defer ticker.Stop()
 		tickerCh = ticker.C
-	} else {
-		// For CLI mode: use a nil channel (will never receive)
-		tickerCh = nil
 	}
 
 	for {
 		select {
-		case msg, ok := <-s.workerStatsCh:
+		case batch, ok := <-r.batches:
 			if !ok {
-				s.stats.EndTime = time.Now()
-				snapshot := s.stats.GetSnapshot()
+				r.stats.mu.Lock()
+				r.stats.EndTime = time.Now()
+				if r.stats.TotalRequests == 0 {
+					r.stats.TotalRequests = r.stats.CompletedRequests
+				}
+				if r.stats.CompletedRequests == 0 {
+					r.stats.MinDuration = 0
+				}
+				r.stats.mu.Unlock()
+				snapshot := r.stats.GetSnapshot()
 				updates <- &snapshot
-				close(updates)
 				return
 			}
-
-			s.stats.mu.Lock()
-			s.stats.CompletedRequests += int(msg.stats.requests)
-			s.stats.FailedRequests += int(msg.stats.failures)
-
-			// Update latency from samples
-			if msg.stats.sampledCount > 0 {
-				minDur := time.Duration(msg.stats.sampledMin)
-				maxDur := time.Duration(msg.stats.sampledMax)
-
-				if s.stats.MinDuration == 0 || minDur < s.stats.MinDuration {
-					s.stats.MinDuration = minDur
-				}
-				if maxDur > s.stats.MaxDuration {
-					s.stats.MaxDuration = maxDur
-				}
-
-				s.stats.TotalDuration += time.Duration(msg.stats.sampledTotal)
-
-				// Add samples to tdigest (average of worker's samples)
-				avgLatency := float64(msg.stats.sampledTotal) / float64(msg.stats.sampledCount)
-				s.stats.Percentiles.digest.Add(avgLatency/1e6, float64(msg.stats.sampledCount))
-			}
-
-			// Merge error codes
-			for code, count := range msg.stats.errorCodes {
-				s.stats.Errors[strconv.Itoa(code)] += int64(count)
-			}
-			s.stats.mu.Unlock()
+			r.mergeBatch(batch)
+			r.releaseBatch(batch)
 
 		case <-tickerCh:
-			// When tickerCh is nil, this case is never selected
-			snapshot := s.stats.GetSnapshot()
-			updates <- &snapshot
+			snapshot := r.stats.GetSnapshot()
+			// Progress snapshots are advisory. Do not let a slow terminal
+			// consumer stall the request engine.
+			select {
+			case updates <- &snapshot:
+			default:
+			}
 		}
 	}
 }
 
-func (s *JobConfig) runWorkers() {
-	var wg sync.WaitGroup
+func (r *runState) mergeBatch(batch *requestBatch) {
+	r.stats.mu.Lock()
+	defer r.stats.mu.Unlock()
 
-	for i := 0; i < s.Concurrency; i++ {
-		wg.Add(1)
-		go s.runWorker(i, &wg)
+	r.stats.CompletedRequests += batch.count
+	r.stats.FailedRequests += batch.failures
+	r.stats.TotalDuration += batch.total
+	r.stats.BytesSent += batch.bytesSent
+	r.stats.BytesRecv += batch.bytesRecv
+	if r.stats.MinDuration == time.Duration(math.MaxInt64) || batch.min < r.stats.MinDuration {
+		r.stats.MinDuration = batch.min
+	}
+	if batch.max > r.stats.MaxDuration {
+		r.stats.MaxDuration = batch.max
 	}
 
-	wg.Wait()
+	r.stats.Percentiles.addBatch(batch.latencies[:batch.count])
+	for i := 0; i < batch.count; i++ {
+		status := int(batch.statuses[i])
+		if status > 0 {
+			r.stats.StatusCodes[status]++
+		}
+		switch {
+		case status >= 400 && status < 500:
+			r.stats.Errors["http_4xx"]++
+		case status >= 500:
+			r.stats.Errors["http_5xx"]++
+		}
+	}
+
+	if batch.timeoutErrs > 0 {
+		r.stats.Errors["timeout"] += int64(batch.timeoutErrs)
+	}
+	if batch.transportErrs > 0 {
+		r.stats.Errors["transport"] += int64(batch.transportErrs)
+	}
+	if batch.canceledErrs > 0 {
+		r.stats.Errors["canceled"] += int64(batch.canceledErrs)
+	}
 }

--- a/internal/http/requester_bench_test.go
+++ b/internal/http/requester_bench_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"testing"
@@ -76,7 +77,7 @@ func BenchmarkEngine_SingleRequest(b *testing.B) {
 					Timeout:       5 * time.Second,
 				}
 
-				config.Run(updates)
+				config.Run(context.Background(), updates)
 				<-done
 			}
 		})
@@ -120,7 +121,7 @@ func BenchmarkEngine_Throughput(b *testing.B) {
 				Timeout:       5 * time.Second,
 			}
 
-			config.Run(updates)
+			config.Run(context.Background(), updates)
 			<-done
 
 			b.StopTimer()
@@ -161,7 +162,7 @@ func BenchmarkEngine_Latency(b *testing.B) {
 		Timeout:       10 * time.Second,
 	}
 
-	config.Run(updates)
+	config.Run(context.Background(), updates)
 	<-done
 
 	b.StopTimer()

--- a/internal/http/requester_test.go
+++ b/internal/http/requester_test.go
@@ -1,161 +1,286 @@
 package http
 
 import (
-	"net/http"
+	"context"
+	"net"
+	stdhttp "net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestJobConfig_BuildWithRequest(t *testing.T) {
-	request := NewDefaultRequest()
-	request.URL = "http://localhost:8080"
-	request.Method = "GET"
+func runJob(t *testing.T, ctx context.Context, config *JobConfig) *LoadTestStats {
+	t.Helper()
+	updates := make(chan *LoadTestStats, 16)
+	done := make(chan struct{})
+	go func() {
+		config.Run(ctx, updates)
+		close(done)
+	}()
 
-	config := &JobConfig{
-		Request:       request,
-		Concurrency:   5,
-		TotalRequests: 50,
-		QPS:           0,
-		Timeout:       5 * time.Second,
+	var final *LoadTestStats
+	for stats := range updates {
+		final = stats
 	}
-
-	if config.Request == nil {
-		t.Fatal("Request is nil")
-	}
-	if config.Request.URL == "" {
-		t.Fatal("Request URL is empty")
-	}
+	<-done
+	require.NotNil(t, final)
+	return final
 }
 
-func TestJobConfig_RunBasic(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(10 * time.Millisecond)
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("ok"))
+func requestFor(url, method, body string) *Request {
+	request := NewDefaultRequest()
+	request.URL = url
+	request.Method = method
+	request.Body = body
+	return request
+}
+
+func TestJobConfigCountModeHasExactAccountingAndTransferStats(t *testing.T) {
+	const responseBody = "response"
+	server := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		_, _ = w.Write([]byte(responseBody))
 	}))
 	defer server.Close()
 
-	request := NewDefaultRequest()
-	request.URL = server.URL
-	request.Method = "GET"
-
-	expectedRequests := 10
-	config := &JobConfig{
-		Request:       request,
-		Concurrency:   2,
-		TotalRequests: 10,
+	const requests = 10_000
+	const requestBody = "ping"
+	stats := runJob(t, context.Background(), &JobConfig{
+		Request:       requestFor(server.URL, "POST", requestBody),
+		Concurrency:   32,
+		TotalRequests: requests,
 		Timeout:       5 * time.Second,
-	}
+	})
 
-	updates := make(chan *LoadTestStats, 10)
-
-	go func() {
-		config.Run(updates)
-	}()
-
-	var finalStats *LoadTestStats
-	timer := time.NewTimer(5 * time.Second)
-	defer timer.Stop()
-
-loop:
-	for {
-		select {
-		case stats, ok := <-updates:
-			if !ok {
-				break loop
-			}
-			if stats != nil {
-				finalStats = stats
-			}
-		case <-timer.C:
-			t.Fatal("Timeout waiting for load test to finish")
-		}
-	}
-
-	assert.NotNil(t, finalStats, "Final stats are nil")
-	assert.Equal(t, expectedRequests, finalStats.CompletedRequests, "Expected %d requests, got %d", expectedRequests, finalStats.CompletedRequests)
-	assert.Equal(t, expectedRequests, finalStats.TotalRequests, "Expected %d requests, got %d", expectedRequests, finalStats.TotalRequests)
-	assert.Equal(t, 0, finalStats.FailedRequests, "Expected 0 failed requests, got %d", finalStats.FailedRequests)
-	assert.NotEqual(t, 0, finalStats.TotalDuration, "Total duration is 0")
-	assert.NotEqual(t, 0, finalStats.StartTime, "Start time is 0")
-	assert.NotEqual(t, 0, finalStats.EndTime, "End time is 0")
-	assert.NotEqual(t, 0, finalStats.MaxDuration, "Max duration is 0")
-	assert.Truef(t, finalStats.MinDuration < finalStats.MaxDuration, "Min duration is greater than max duration (%d > %d)", finalStats.MinDuration, finalStats.MaxDuration)
-	assert.NotNil(t, finalStats.Percentiles, "Percentiles are nil")
-
+	assert.Equal(t, requests, stats.CompletedRequests)
+	assert.Equal(t, requests, stats.TotalRequests)
+	assert.Zero(t, stats.FailedRequests)
+	assert.Equal(t, int64(requests*len(requestBody)), stats.BytesSent)
+	assert.Equal(t, int64(requests*len(responseBody)), stats.BytesRecv)
+	assert.Equal(t, int64(requests), stats.StatusCodes[stdhttp.StatusOK])
+	assert.Equal(t, requests, int(stats.Percentiles.digest.Count()))
+	assert.Positive(t, stats.TotalDuration)
+	assert.Positive(t, stats.MeanDuration())
+	assert.Positive(t, stats.MinDuration)
+	assert.GreaterOrEqual(t, stats.MaxDuration, stats.MinDuration)
 }
 
-func TestJobConfig_RunHard(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(10 * time.Millisecond)
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("ok"))
+func TestJobConfigDurationModeRunsForConfiguredDuration(t *testing.T) {
+	server := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		time.Sleep(2 * time.Millisecond)
+		w.WriteHeader(stdhttp.StatusNoContent)
 	}))
 	defer server.Close()
 
-	request := NewDefaultRequest()
-	request.URL = server.URL
-	request.Method = "GET"
+	const duration = 150 * time.Millisecond
+	stats := runJob(t, context.Background(), &JobConfig{
+		Request:     requestFor(server.URL, "GET", ""),
+		Concurrency: 4,
+		Duration:    duration,
+		Timeout:     time.Second,
+	})
 
-	expectedRequests := 100_000
-	config := &JobConfig{
-		Request:       request,
-		Concurrency:   500,
-		TotalRequests: expectedRequests,
-		Timeout:       5 * time.Second,
-	}
-	updates := make(chan *LoadTestStats, 10)
+	elapsed := stats.EndTime.Sub(stats.StartTime)
+	assert.GreaterOrEqual(t, elapsed, duration-10*time.Millisecond)
+	assert.Less(t, elapsed, duration+250*time.Millisecond)
+	assert.Positive(t, stats.CompletedRequests)
+	assert.Equal(t, stats.CompletedRequests, stats.TotalRequests)
+}
 
-	go func() {
-		config.Run(updates)
-	}()
-	var finalStats *LoadTestStats
-	timer := time.NewTimer(5 * time.Second)
-	defer timer.Stop()
+func TestJobConfigRateLimitIsGlobalAcrossWorkers(t *testing.T) {
+	server := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		w.WriteHeader(stdhttp.StatusNoContent)
+	}))
+	defer server.Close()
 
-loop:
-	for {
+	stats := runJob(t, context.Background(), &JobConfig{
+		Request:       requestFor(server.URL, "GET", ""),
+		Concurrency:   6,
+		TotalRequests: 6,
+		QPS:           10,
+		Timeout:       time.Second,
+	})
+
+	// One immediate start plus five globally spaced 100 ms starts.
+	elapsed := stats.EndTime.Sub(stats.StartTime)
+	assert.GreaterOrEqual(t, elapsed, 450*time.Millisecond)
+	assert.Less(t, elapsed, 2*time.Second)
+	assert.Equal(t, 6, stats.CompletedRequests)
+}
+
+func TestJobConfigContextCancellationStopsWorkersAndReturnsFinalStats(t *testing.T) {
+	started := make(chan struct{}, 1)
+	server := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
 		select {
-		case stats, ok := <-updates:
-			if !ok {
-				break loop
-			}
-			if stats != nil {
-				finalStats = stats
-			}
-		case <-timer.C:
-			t.Fatal("Timeout waiting for load test to finish")
+		case started <- struct{}{}:
+		default:
 		}
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-started
+		cancel()
+	}()
+
+	start := time.Now()
+	stats := runJob(t, ctx, &JobConfig{
+		Request:       requestFor(server.URL, "GET", ""),
+		Concurrency:   20,
+		TotalRequests: 1_000_000,
+		Timeout:       5 * time.Second,
+	})
+
+	assert.Less(t, time.Since(start), time.Second)
+	assert.LessOrEqual(t, stats.CompletedRequests, 20)
+	assert.GreaterOrEqual(t, stats.CompletedRequests, 1)
+	assert.Equal(t, int64(stats.CompletedRequests), stats.Errors["canceled"])
+	assert.Equal(t, stats.CompletedRequests, int(stats.Percentiles.digest.Count()))
+}
+
+func TestPercentilesUseRequestDistribution(t *testing.T) {
+	calculator := newPercentileCalculator()
+	for i := 0; i < 90; i++ {
+		calculator.add(time.Millisecond)
+	}
+	for i := 0; i < 10; i++ {
+		calculator.add(100 * time.Millisecond)
 	}
 
-	assert.NotNil(t, finalStats, "Final stats are nil")
-	assert.Equal(t, expectedRequests, finalStats.CompletedRequests, "Expected %d requests, got %d", expectedRequests, finalStats.CompletedRequests)
-	assert.Equal(t, expectedRequests, finalStats.TotalRequests, "Expected %d requests, got %d", expectedRequests, finalStats.TotalRequests)
-	assert.Equal(t, 0, finalStats.FailedRequests, "Expected 0 failed requests, got %d", finalStats.FailedRequests)
-	assert.NotEqual(t, 0, finalStats.TotalDuration, "Total duration is 0")
-	assert.NotEqual(t, 0, finalStats.StartTime, "Start time is 0")
-	assert.NotEqual(t, 0, finalStats.EndTime, "End time is 0")
-	assert.NotEqual(t, 0, finalStats.MaxDuration, "Max duration is 0")
-	assert.Truef(t, finalStats.MinDuration < finalStats.MaxDuration, "Min duration is greater than max duration (%d > %d)", finalStats.MinDuration, finalStats.MaxDuration)
-	assert.NotNil(t, finalStats.Percentiles, "Percentiles are nil")
+	assert.Less(t, calculator.Percentile(50), 5*time.Millisecond)
+	assert.Greater(t, calculator.Percentile(95), 50*time.Millisecond)
+}
+
+func TestPercentilesPreserveSubMillisecondPrecision(t *testing.T) {
+	calculator := newPercentileCalculator()
+	calculator.add(700 * time.Microsecond)
+
+	assert.Equal(t, 700*time.Microsecond, calculator.Percentile(50))
+}
+
+func TestMeanLatencyUsesEveryCompletedRequest(t *testing.T) {
+	state := &runState{stats: NewLoadTestStats(2)}
+	batch := &requestBatch{
+		count:     2,
+		total:     400 * time.Microsecond,
+		min:       100 * time.Microsecond,
+		max:       300 * time.Microsecond,
+		latencies: [statsBatchSize]time.Duration{100 * time.Microsecond, 300 * time.Microsecond},
+		statuses:  [statsBatchSize]uint16{200, 200},
+	}
+	state.mergeBatch(batch)
+
+	assert.Equal(t, 200*time.Microsecond, state.stats.MeanDuration())
+	assert.Equal(t, 2, state.stats.CompletedRequests)
+	assert.Equal(t, 2, int(state.stats.Percentiles.digest.Count()))
+}
+
+func TestHTTPFailuresAndStatusCodesAreClassified(t *testing.T) {
+	var sequence atomic.Int64
+	server := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		switch sequence.Add(1) {
+		case 1:
+			w.WriteHeader(stdhttp.StatusBadRequest)
+		case 2:
+			w.WriteHeader(stdhttp.StatusServiceUnavailable)
+		default:
+			w.WriteHeader(stdhttp.StatusNoContent)
+		}
+	}))
+	defer server.Close()
+
+	stats := runJob(t, context.Background(), &JobConfig{
+		Request:       requestFor(server.URL, "GET", ""),
+		Concurrency:   1,
+		TotalRequests: 3,
+		Timeout:       time.Second,
+	})
+
+	assert.Equal(t, 2, stats.FailedRequests)
+	assert.Equal(t, int64(1), stats.StatusCodes[stdhttp.StatusBadRequest])
+	assert.Equal(t, int64(1), stats.StatusCodes[stdhttp.StatusServiceUnavailable])
+	assert.Equal(t, int64(1), stats.StatusCodes[stdhttp.StatusNoContent])
+	assert.Equal(t, int64(1), stats.Errors["http_4xx"])
+	assert.Equal(t, int64(1), stats.Errors["http_5xx"])
+}
+
+func TestTransportAndTimeoutErrorsAreClassified(t *testing.T) {
+	t.Run("transport", func(t *testing.T) {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		url := "http://" + listener.Addr().String()
+		require.NoError(t, listener.Close())
+
+		stats := runJob(t, context.Background(), &JobConfig{
+			Request:       requestFor(url, "GET", ""),
+			Concurrency:   1,
+			TotalRequests: 1,
+			Timeout:       100 * time.Millisecond,
+		})
+		assert.Equal(t, 1, stats.CompletedRequests)
+		assert.Equal(t, 1, stats.FailedRequests)
+		assert.Equal(t, int64(1), stats.Errors["transport"])
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		server := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+			time.Sleep(100 * time.Millisecond)
+			w.WriteHeader(stdhttp.StatusNoContent)
+		}))
+		defer server.Close()
+
+		stats := runJob(t, context.Background(), &JobConfig{
+			Request:       requestFor(server.URL, "GET", ""),
+			Concurrency:   1,
+			TotalRequests: 1,
+			Timeout:       10 * time.Millisecond,
+		})
+		assert.Equal(t, 1, stats.FailedRequests)
+		assert.Equal(t, int64(1), stats.Errors["timeout"])
+	})
+}
+
+func TestKeepAliveConfigurationControlsConnectionReuse(t *testing.T) {
+	run := func(t *testing.T, keepAlive bool) int64 {
+		t.Helper()
+		var newConnections atomic.Int64
+		server := httptest.NewUnstartedServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+			_, _ = w.Write([]byte("ok"))
+		}))
+		server.Config.ConnState = func(_ net.Conn, state stdhttp.ConnState) {
+			if state == stdhttp.StateNew {
+				newConnections.Add(1)
+			}
+		}
+		server.Start()
+		defer server.Close()
+
+		stats := runJob(t, context.Background(), &JobConfig{
+			Request:          requestFor(server.URL, "GET", ""),
+			Concurrency:      1,
+			TotalRequests:    5,
+			Timeout:          time.Second,
+			DisableKeepAlive: !keepAlive,
+		})
+		require.Equal(t, 5, stats.CompletedRequests)
+		return newConnections.Load()
+	}
+
+	assert.Equal(t, int64(1), run(t, true))
+	assert.GreaterOrEqual(t, run(t, false), int64(5))
 }
 
 func TestNewLoadTestStats(t *testing.T) {
 	stats := NewLoadTestStats(100)
-
-	if stats == nil {
-		t.Fatal("NewLoadTestStats returned nil")
-	}
-	if stats.TotalRequests != 100 {
-		t.Errorf("Expected TotalRequests=100, got %d", stats.TotalRequests)
-	}
-	if stats.Percentiles == nil {
-		t.Fatal("Percentiles not initialized")
-	}
-	if stats.Errors == nil {
-		t.Fatal("Errors map not initialized")
-	}
+	require.NotNil(t, stats)
+	assert.Equal(t, 100, stats.TotalRequests)
+	assert.NotNil(t, stats.Percentiles)
+	assert.NotNil(t, stats.Errors)
+	assert.NotNil(t, stats.StatusCodes)
+	assert.Zero(t, stats.MeanDuration())
 }

--- a/internal/http/requester_test.go
+++ b/internal/http/requester_test.go
@@ -68,6 +68,44 @@ func TestJobConfigCountModeHasExactAccountingAndTransferStats(t *testing.T) {
 	assert.GreaterOrEqual(t, stats.MaxDuration, stats.MinDuration)
 }
 
+func TestJobConfigWithNoPositiveExecutionBoundFinishesWithoutWork(t *testing.T) {
+	tests := map[string]JobConfig{
+		"zero bounds":     {Concurrency: 4},
+		"negative bounds": {Concurrency: 4, Duration: -time.Second, TotalRequests: -1},
+	}
+	for name, config := range tests {
+		t.Run(name, func(t *testing.T) {
+			updates := make(chan *LoadTestStats, 1)
+			done := make(chan struct{})
+			go func() {
+				config.Run(context.Background(), updates)
+				close(done)
+			}()
+
+			select {
+			case stats, ok := <-updates:
+				require.True(t, ok)
+				require.NotNil(t, stats)
+				assert.Zero(t, stats.TotalRequests)
+				assert.Zero(t, stats.CompletedRequests)
+				assert.Zero(t, stats.FailedRequests)
+				assert.Zero(t, stats.MinDuration)
+				assert.False(t, stats.EndTime.IsZero())
+			case <-time.After(time.Second):
+				t.Fatal("zero-work job did not terminate")
+			}
+
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+				t.Fatal("zero-work job did not return")
+			}
+			_, ok := <-updates
+			assert.False(t, ok, "updates channel should be closed")
+		})
+	}
+}
+
 func TestJobConfigDurationModeRunsForConfiguredDuration(t *testing.T) {
 	server := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
 		time.Sleep(2 * time.Millisecond)

--- a/internal/ui/responsepane/renderer_loadtest.go
+++ b/internal/ui/responsepane/renderer_loadtest.go
@@ -135,9 +135,9 @@ func (m ResponsePane) renderLoadTestErrors() string {
 		return b.String()
 	}
 
-	// Render each error code with styling
-	for code, count := range stats.Errors {
-		b.WriteString(responseKeyStyle.Render(fmt.Sprintf("HTTP %s", code)))
+	// Render each stable error class.
+	for class, count := range stats.Errors {
+		b.WriteString(responseKeyStyle.Render(class))
 		b.WriteString(": ")
 		b.WriteString(responseValueStyle.Render(fmt.Sprintf("%d occurrences", count)))
 		b.WriteString("\n\n")

--- a/internal/ui/responsepane/renderer_loadtest.go
+++ b/internal/ui/responsepane/renderer_loadtest.go
@@ -2,6 +2,7 @@ package responsepane
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 )
@@ -136,7 +137,14 @@ func (m ResponsePane) renderLoadTestErrors() string {
 	}
 
 	// Render each stable error class.
-	for class, count := range stats.Errors {
+	errorClasses := make([]string, 0, len(stats.Errors))
+	for class := range stats.Errors {
+		errorClasses = append(errorClasses, class)
+	}
+	sort.Strings(errorClasses)
+
+	for _, class := range errorClasses {
+		count := stats.Errors[class]
 		b.WriteString(responseKeyStyle.Render(class))
 		b.WriteString(": ")
 		b.WriteString(responseValueStyle.Render(fmt.Sprintf("%d occurrences", count)))


### PR DESCRIPTION
## Summary

This makes Volt load-test results trustworthy enough to support future comparative benchmark work.

- run duration mode against a real deadline
- enforce QPS once across the complete run instead of once per worker
- preserve exact completed, failed, status, byte, and cancellation counts
- calculate mean and percentile latency from every request at nanosecond precision
- classify HTTP 4xx/5xx, timeout, transport, and cancellation failures
- propagate CLI signals through workers and interrupt active network operations
- honor keep-alive configuration and expose -no-keepalive
- reject invalid execution bounds and terminate defensively when no positive bound exists

## Tests

- go test ./...
- go test -race ./...
- go vet ./...
- repeated HTTP correctness suite
- exact 10,000-request accounting
- duration, global-rate, in-flight cancellation, distribution, sub-millisecond, transfer, status, and connection-reuse tests

## Performance

Local Apple M4 loopback comparisons remained effectively flat. The longer concurrency-10 run measured 148,397 req/s versus 148,248 req/s on main. Concurrency 50, 100, and 500 medians were flat to slightly improved within expected short-run variance.

## Boundaries

Transfer counters intentionally report application payload bytes and exclude headers and transport framing. The CLI owns signal cancellation in this change; a future terminal UX change can give the TUI a model-owned cancellation context without further engine changes.