### PR TITLE
Improve user-facing error handling

### DIFF
--- a/internal/app/notification_test.go
+++ b/internal/app/notification_test.go
@@ -18,6 +18,7 @@ func TestStorageResultsSurfaceConfirmationsAndErrors(t *testing.T) {
 		msg   any
 		level ui.NotificationLevel
 		text  string
+		hint  string
 	}{
 		{
 			name:  "save success",
@@ -29,7 +30,8 @@ func TestStorageResultsSurfaceConfirmationsAndErrors(t *testing.T) {
 			name:  "save failure",
 			msg:   ui.RequestSavedMsg{Err: errors.New("disk full")},
 			level: ui.NotificationError,
-			text:  "disk full",
+			text:  "access saved",
+			hint:  "disk space",
 		},
 		{
 			name:  "delete success",
@@ -41,13 +43,15 @@ func TestStorageResultsSurfaceConfirmationsAndErrors(t *testing.T) {
 			name:  "delete failure",
 			msg:   ui.RequestDeletedMsg{Err: errors.New("database locked")},
 			level: ui.NotificationError,
-			text:  "database locked",
+			text:  "saved requests are busy",
+			hint:  "try again",
 		},
 		{
 			name:  "load failure",
 			msg:   ui.RequestsLoadingMsg{Err: errors.New("corrupt database")},
 			level: ui.NotificationError,
-			text:  "corrupt database",
+			text:  "update saved",
+			hint:  "try again",
 		},
 		{
 			name:  "copy success",
@@ -59,7 +63,8 @@ func TestStorageResultsSurfaceConfirmationsAndErrors(t *testing.T) {
 			name:  "copy failure",
 			msg:   responsepane.ResponseCopiedMsg{Err: errors.New("clipboard unavailable")},
 			level: ui.NotificationError,
-			text:  "clipboard unavailable",
+			text:  "couldn't copy",
+			hint:  "clipboard",
 		},
 	}
 
@@ -75,6 +80,9 @@ func TestStorageResultsSurfaceConfirmationsAndErrors(t *testing.T) {
 			if !strings.Contains(strings.ToLower(got.notification.Text), tt.text) {
 				t.Fatalf("notification = %q, want it to contain %q", got.notification.Text, tt.text)
 			}
+			if tt.hint != "" && !strings.Contains(strings.ToLower(got.notification.Hint), tt.hint) {
+				t.Fatalf("notification hint = %q, want it to contain %q", got.notification.Hint, tt.hint)
+			}
 		})
 	}
 }
@@ -85,6 +93,7 @@ func TestRequestAndLoadTestOutcomesSurfaceStatus(t *testing.T) {
 		msg   any
 		level ui.NotificationLevel
 		text  string
+		hint  string
 	}{
 		{
 			name: "request transport error",
@@ -92,7 +101,8 @@ func TestRequestAndLoadTestOutcomesSurfaceStatus(t *testing.T) {
 				Error: "connection refused",
 			}},
 			level: ui.NotificationError,
-			text:  "connection refused",
+			text:  "connect to the server",
+			hint:  "server is running",
 		},
 		{
 			name: "request HTTP failure",
@@ -101,13 +111,15 @@ func TestRequestAndLoadTestOutcomesSurfaceStatus(t *testing.T) {
 				Status:     "503 Service Unavailable",
 			}},
 			level: ui.NotificationError,
-			text:  "503",
+			text:  "server returned http 503",
+			hint:  "try again",
 		},
 		{
 			name:  "load-test runtime error",
 			msg:   http.LoadTestErrorMsg{Error: errors.New("unable to start")},
 			level: ui.NotificationError,
-			text:  "unable to start",
+			text:  "couldn't start the load test",
+			hint:  "settings",
 		},
 		{
 			name: "load-test HTTP failures",
@@ -116,7 +128,8 @@ func TestRequestAndLoadTestOutcomesSurfaceStatus(t *testing.T) {
 				FailedRequests:    2,
 			}},
 			level: ui.NotificationError,
-			text:  "2 failed",
+			text:  "2 requests failed",
+			hint:  "url and connection",
 		},
 		{
 			name: "load-test success",
@@ -140,6 +153,9 @@ func TestRequestAndLoadTestOutcomesSurfaceStatus(t *testing.T) {
 			if !strings.Contains(strings.ToLower(got.notification.Text), tt.text) {
 				t.Fatalf("notification = %q, want it to contain %q", got.notification.Text, tt.text)
 			}
+			if tt.hint != "" && !strings.Contains(strings.ToLower(got.notification.Hint), tt.hint) {
+				t.Fatalf("notification hint = %q, want it to contain %q", got.notification.Hint, tt.hint)
+			}
 			if got.focusedPanel != utils.ResponsePanel {
 				t.Fatalf("focused panel = %d, want response", got.focusedPanel)
 			}
@@ -152,10 +168,45 @@ func TestNotificationIsVisibleInStatusLine(t *testing.T) {
 	model.notification = ui.Notification{
 		Level: ui.NotificationError,
 		Text:  "load test failed",
+		Hint:  "try again",
 	}
 
-	if view := model.View().Content; !strings.Contains(view, "load test failed") {
+	if view := model.View().Content; !strings.Contains(view, "load test failed") || !strings.Contains(view, "try again") {
 		t.Fatalf("view does not contain notification:\n%s", view)
+	}
+}
+
+func TestRequestErrorsHideRawTransportDetailsAndShowRecoveryHint(t *testing.T) {
+	model := newTestModel(t)
+	updated, _ := model.Update(http.ResultMsg{Response: &http.Response{Error: "dial tcp 127.0.0.1:8080: connect: connection refused"}})
+	got := updated.(Model)
+
+	if strings.Contains(got.notification.Text, "127.0.0.1") {
+		t.Fatalf("notification exposes transport detail: %q", got.notification.Text)
+	}
+	if !strings.Contains(strings.ToLower(got.notification.Hint), "server is running") {
+		t.Fatalf("notification hint = %q", got.notification.Hint)
+	}
+	if got.responsePane.Response == nil || strings.Contains(got.responsePane.Response.Error, "127.0.0.1") {
+		t.Fatalf("response exposes transport detail: %#v", got.responsePane.Response)
+	}
+}
+
+func TestUnexpectedUIPanicRecoversWithoutStackTrace(t *testing.T) {
+	model := newTestModel(t)
+	updated, cmd := recoverUpdate(model, func() (tea.Model, tea.Cmd) {
+		panic("sensitive implementation detail")
+	})
+	got := updated.(Model)
+
+	if cmd != nil {
+		t.Fatal("panic recovery returned an unexpected command")
+	}
+	if strings.Contains(got.notification.Text, "sensitive") {
+		t.Fatalf("panic detail leaked into notification: %q", got.notification.Text)
+	}
+	if !strings.Contains(got.notification.Hint, "?") {
+		t.Fatalf("panic recovery hint = %q", got.notification.Hint)
 	}
 }
 

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -2,10 +2,12 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/owenHochwald/Volt/internal/apperror"
 	"github.com/owenHochwald/Volt/internal/http"
 	"github.com/owenHochwald/Volt/internal/ui"
 	"github.com/owenHochwald/Volt/internal/ui/keybindings"
@@ -23,7 +25,27 @@ type quitSequenceExpiredMsg struct {
 	sequence uint64
 }
 
-func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+// Update prevents an unexpected UI panic from terminating Volt. The recovery
+// message intentionally omits implementation details and stack traces.
+func (m Model) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
+	return recoverUpdate(m, func() (tea.Model, tea.Cmd) {
+		return m.update(msg)
+	})
+}
+
+func recoverUpdate(m Model, update func() (tea.Model, tea.Cmd)) (model tea.Model, cmd tea.Cmd) {
+	model = m
+	defer func() {
+		if recover() != nil {
+			m.notification = ui.ErrorNotification(apperror.ApplicationError())
+			model = m
+			cmd = nil
+		}
+	}()
+	return update()
+}
+
+func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 
 	switch msg := msg.(type) {
@@ -105,15 +127,27 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case http.ResultMsg:
 		m.requestPane.ResultMsgCleanup()
-		m.responsePane.SetResponse(msg.Response)
 		m.setFocusedPanel(utils.ResponsePanel)
+		if msg.Response == nil {
+			failure := apperror.OperationError("Volt didn't receive a response.", "Try the request again.")
+			msg.Response = &http.Response{Error: failure.Message, Failure: failure}
+		}
+		if msg.Response.Error != "" {
+			failure := msg.Response.Failure
+			if failure == nil {
+				failure = apperror.FromNetwork(errors.New(msg.Response.Error))
+			}
+			msg.Response.Error = failure.Message
+			msg.Response.Failure = failure
+			m.responsePane.SetResponse(msg.Response)
+			m.notification = ui.ErrorNotification(failure)
+			return m, nil
+		}
+
+		m.responsePane.SetResponse(msg.Response)
 		switch {
-		case msg.Response == nil:
-			m.notification = ui.Notification{Level: ui.NotificationError, Text: "Request failed: empty response"}
-		case msg.Response.Error != "":
-			m.notification = ui.Notification{Level: ui.NotificationError, Text: "Request failed: " + msg.Response.Error}
 		case msg.Response.StatusCode >= 400:
-			m.notification = ui.Notification{Level: ui.NotificationError, Text: "Request completed with " + msg.Response.Status}
+			m.notification = ui.ErrorNotification(apperror.HTTPStatus(msg.Response.StatusCode))
 		default:
 			m.notification = ui.Notification{Level: ui.NotificationSuccess, Text: "Request completed with " + msg.Response.Status}
 		}
@@ -121,7 +155,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case ui.RequestSavedMsg:
 		if msg.Err != nil {
-			m.notification = ui.Notification{Level: ui.NotificationError, Text: "Save failed: " + msg.Err.Error()}
+			m.notification = ui.ErrorNotification(apperror.FromStorage(msg.Err))
 			return m, nil
 		}
 		m.notification = ui.Notification{Level: ui.NotificationSuccess, Text: "Request saved"}
@@ -129,7 +163,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case ui.RequestDeletedMsg:
 		if msg.Err != nil {
-			m.notification = ui.Notification{Level: ui.NotificationError, Text: "Delete failed: " + msg.Err.Error()}
+			m.notification = ui.ErrorNotification(apperror.FromStorage(msg.Err))
 			return m, nil
 		}
 		m.notification = ui.Notification{Level: ui.NotificationSuccess, Text: "Request deleted"}
@@ -137,7 +171,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case ui.RequestsLoadingMsg:
 		if msg.Err != nil {
-			m.notification = ui.Notification{Level: ui.NotificationError, Text: "Loading requests failed: " + msg.Err.Error()}
+			m.notification = ui.ErrorNotification(apperror.FromStorage(msg.Err))
 			return m, nil
 		}
 		m.sidebarPane, cmd = m.sidebarPane.Update(msg)
@@ -149,7 +183,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case responsepane.ResponseCopiedMsg:
 		if msg.Err != nil {
-			m.notification = ui.Notification{Level: ui.NotificationError, Text: "Copy failed: " + msg.Err.Error()}
+			m.notification = ui.ErrorNotification(apperror.OperationError("Volt couldn't copy the response.", "Try again after checking clipboard access."))
 		} else {
 			m.notification = ui.Notification{Level: ui.NotificationSuccess, Text: "Response copied"}
 		}
@@ -198,12 +232,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				Text:  fmt.Sprintf("Load test canceled after %d requests", completed),
 			}
 		case msg.Stats == nil:
-			m.notification = ui.Notification{Level: ui.NotificationError, Text: "Load test ended without final statistics"}
+			m.notification = ui.ErrorNotification(apperror.OperationError("Load test ended without final results.", "Try the load test again."))
 		case msg.Stats.FailedRequests > 0:
-			m.notification = ui.Notification{
-				Level: ui.NotificationError,
-				Text:  fmt.Sprintf("Load test complete: %d failed requests", msg.Stats.FailedRequests),
-			}
+			m.notification = ui.ErrorNotification(apperror.LoadTestFailure(msg.Stats.FailedRequests, msg.Stats.Errors))
 		default:
 			m.notification = ui.Notification{
 				Level: ui.NotificationSuccess,
@@ -221,11 +252,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.requestPane.ExitLoadTestMode()
 		m.setFocusedPanel(utils.ResponsePanel)
-		errorText := "unknown error"
-		if msg.Error != nil {
-			errorText = msg.Error.Error()
-		}
-		m.notification = ui.Notification{Level: ui.NotificationError, Text: "Load test failed: " + errorText}
+		m.notification = ui.ErrorNotification(apperror.OperationError("Volt couldn't start the load test.", "Check the load test settings and try again."))
 		return m, nil
 
 	case tea.WindowSizeMsg:

--- a/internal/apperror/error.go
+++ b/internal/apperror/error.go
@@ -1,0 +1,206 @@
+// Package apperror defines the small, user-facing error vocabulary used by Volt.
+// It deliberately keeps implementation details out of messages shown in the UI.
+package apperror
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+)
+
+type Category string
+
+const (
+	Network     Category = "network"
+	Validation  Category = "validation"
+	Storage     Category = "storage"
+	Application Category = "application"
+)
+
+type Code string
+
+const (
+	Timeout           Code = "timeout"
+	DNS               Code = "dns"
+	ConnectionRefused Code = "connection_refused"
+	Transport         Code = "transport"
+	HTTPClientError   Code = "http_4xx"
+	HTTPServerError   Code = "http_5xx"
+
+	InvalidURLCode Code = "invalid_url"
+	InvalidHeaders Code = "invalid_headers"
+	InvalidJSON    Code = "invalid_json"
+	InvalidConfig  Code = "invalid_config"
+
+	DatabaseLocked Code = "database_locked"
+	StorageIO      Code = "storage_io"
+
+	Unexpected Code = "unexpected"
+)
+
+// Error is safe to display to a user. Message explains what happened, and Hint
+// is a compact, actionable next step for the notification area.
+type Error struct {
+	Category Category
+	Code     Code
+	Message  string
+	Hint     string
+
+	cause error
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Message
+}
+
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+func FromNetwork(err error) *Error {
+	if typed, ok := asAppError(err); ok {
+		return typed
+	}
+
+	lower := strings.ToLower(errorText(err))
+	if errors.Is(err, context.DeadlineExceeded) || strings.Contains(lower, "timeout") || strings.Contains(lower, "deadline exceeded") {
+		return newError(Network, Timeout, "The request timed out.", "Try again or increase the timeout.", err)
+	}
+
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) || strings.Contains(lower, "no such host") || strings.Contains(lower, "server misbehaving") {
+		return newError(Network, DNS, "Volt couldn't find the host.", "Check the URL for typos, then try again.", err)
+	}
+
+	if strings.Contains(lower, "connection refused") {
+		return newError(Network, ConnectionRefused, "Volt couldn't connect to the server.", "Check that the server is running, then try again.", err)
+	}
+
+	return newError(Network, Transport, "Volt couldn't complete the request.", "Check your connection and try again.", err)
+}
+
+func InvalidURL(value string) *Error {
+	hint := "Enter a complete URL beginning with http:// or https://."
+	trimmed := strings.TrimSpace(value)
+	if trimmed != "" && !strings.Contains(trimmed, "://") {
+		hint = fmt.Sprintf("Did you mean https://%s?", trimmed)
+	}
+	return newError(Validation, InvalidURLCode, "The URL is not valid.", hint, nil)
+}
+
+func ValidationError(code Code, message, hint string) *Error {
+	return newError(Validation, code, message, hint, nil)
+}
+
+func FromStorage(err error) *Error {
+	if typed, ok := asAppError(err); ok {
+		return typed
+	}
+
+	lower := strings.ToLower(errorText(err))
+	if strings.Contains(lower, "database is locked") || strings.Contains(lower, "database locked") || strings.Contains(lower, "database is busy") {
+		return newError(Storage, DatabaseLocked, "Saved requests are busy right now.", "Wait a moment, then try again.", err)
+	}
+	if strings.Contains(lower, "i/o") || strings.Contains(lower, "no space") || strings.Contains(lower, "disk full") || strings.Contains(lower, "permission denied") {
+		return newError(Storage, StorageIO, "Volt couldn't access saved requests.", "Check available disk space and permissions, then try again.", err)
+	}
+	return newError(Storage, StorageIO, "Volt couldn't update saved requests.", "Try again in a moment.", err)
+}
+
+func HTTPStatus(status int) *Error {
+	switch {
+	case status == 429:
+		return newError(Network, HTTPClientError, "The server is rate limiting this request.", "Wait a moment before trying again or lower the load-test QPS.", nil)
+	case status >= 500:
+		return newError(Network, HTTPServerError, fmt.Sprintf("The server returned HTTP %d.", status), "Try again in a moment.", nil)
+	default:
+		return newError(Network, HTTPClientError, fmt.Sprintf("The server rejected the request (HTTP %d).", status), "Check the URL, headers, and body, then try again.", nil)
+	}
+}
+
+// LoadTestFailure condenses a run's failure classes into one actionable status
+// notification while preserving the complete per-class breakdown in the result pane.
+func LoadTestFailure(failed int, classes map[string]int64) *Error {
+	if classes[string(Timeout)] > 0 {
+		return newError(
+			Network,
+			Timeout,
+			fmt.Sprintf("Load test completed: %d requests failed (%d timed out).", failed, classes[string(Timeout)]),
+			"Try again or increase the timeout.",
+			nil,
+		)
+	}
+	if classes[string(DNS)] > 0 {
+		return newError(Network, DNS, fmt.Sprintf("Load test completed: %d requests failed because the host could not be found.", failed), "Check the URL for typos, then try again.", nil)
+	}
+	if classes[string(ConnectionRefused)] > 0 {
+		return newError(Network, ConnectionRefused, fmt.Sprintf("Load test completed: %d requests could not connect to the server.", failed), "Check that the server is running, then try again.", nil)
+	}
+	if classes[string(HTTPServerError)] > 0 {
+		return newError(Network, HTTPServerError, fmt.Sprintf("Load test completed: %d requests failed with server errors.", failed), "Try again in a moment.", nil)
+	}
+	return newError(Network, Transport, fmt.Sprintf("Load test completed: %d requests failed.", failed), "Check the URL and connection, then try again.", nil)
+}
+
+func ApplicationError() *Error {
+	return newError(Application, Unexpected, "Volt recovered from an unexpected error.", "Press ? to see available keybindings, then try again.", nil)
+}
+
+func FromApplication(err error) *Error {
+	if typed, ok := asAppError(err); ok {
+		return typed
+	}
+	return newError(Application, Unexpected, "Volt couldn't complete that action.", "Press ? to see available keybindings, then try again.", err)
+}
+
+func OperationError(message, hint string) *Error {
+	return newError(Application, Unexpected, message, hint, nil)
+}
+
+func ErrorClassLabel(class string) string {
+	switch Code(class) {
+	case Timeout:
+		return "Timed out"
+	case DNS:
+		return "Host not found"
+	case ConnectionRefused:
+		return "Connection refused"
+	case Transport:
+		return "Connection errors"
+	case HTTPClientError:
+		return "HTTP 4xx responses"
+	case HTTPServerError:
+		return "HTTP 5xx responses"
+	case "canceled":
+		return "Canceled"
+	default:
+		return class
+	}
+}
+
+func newError(category Category, code Code, message, hint string, cause error) *Error {
+	return &Error{Category: category, Code: code, Message: message, Hint: hint, cause: cause}
+}
+
+func asAppError(err error) (*Error, bool) {
+	var typed *Error
+	if errors.As(err, &typed) {
+		return typed, true
+	}
+	return nil, false
+}
+
+func errorText(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/internal/apperror/error_test.go
+++ b/internal/apperror/error_test.go
@@ -1,0 +1,95 @@
+package apperror
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+)
+
+func TestNetworkErrorsHaveFriendlyMessagesAndRecoveryHints(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantCode Code
+		message  string
+		hint     string
+	}{
+		{
+			name:     "timeout",
+			err:      context.DeadlineExceeded,
+			wantCode: Timeout,
+			message:  "timed out",
+			hint:     "increase the timeout",
+		},
+		{
+			name:     "DNS lookup",
+			err:      &net.DNSError{Name: "volt.invalid", IsNotFound: true},
+			wantCode: DNS,
+			message:  "find the host",
+			hint:     "Check the URL",
+		},
+		{
+			name:     "connection refused",
+			err:      errors.New("dial tcp 127.0.0.1:8080: connect: connection refused"),
+			wantCode: ConnectionRefused,
+			message:  "connect to the server",
+			hint:     "server is running",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FromNetwork(tt.err)
+			if got.Category != Network || got.Code != tt.wantCode {
+				t.Fatalf("error = (%s, %s), want (%s, %s)", got.Category, got.Code, Network, tt.wantCode)
+			}
+			if !containsFold(got.Message, tt.message) {
+				t.Fatalf("message = %q, want it to contain %q", got.Message, tt.message)
+			}
+			if !containsFold(got.Hint, tt.hint) {
+				t.Fatalf("hint = %q, want it to contain %q", got.Hint, tt.hint)
+			}
+		})
+	}
+}
+
+func containsFold(value, substring string) bool {
+	return strings.Contains(strings.ToLower(value), strings.ToLower(substring))
+}
+
+func TestValidationAndStorageErrorsAreCategorized(t *testing.T) {
+	invalidURL := InvalidURL("example.com")
+	if invalidURL.Category != Validation || invalidURL.Code != InvalidURLCode {
+		t.Fatalf("invalid URL = (%s, %s)", invalidURL.Category, invalidURL.Code)
+	}
+	if !containsFold(invalidURL.Hint, "https://example.com") {
+		t.Fatalf("invalid URL hint = %q", invalidURL.Hint)
+	}
+
+	locked := FromStorage(errors.New("database locked"))
+	if locked.Category != Storage || locked.Code != DatabaseLocked {
+		t.Fatalf("locked database = (%s, %s)", locked.Category, locked.Code)
+	}
+	if !containsFold(locked.Hint, "try again") {
+		t.Fatalf("storage hint = %q", locked.Hint)
+	}
+}
+
+func TestLoadTestFailureSummaryPrioritizesRecoverableNetworkFailures(t *testing.T) {
+	got := LoadTestFailure(5, map[string]int64{
+		string(Timeout): 3,
+		"http_5xx":      2,
+	})
+
+	if got.Category != Network || got.Code != Timeout {
+		t.Fatalf("error = (%s, %s), want (%s, %s)", got.Category, got.Code, Network, Timeout)
+	}
+	if !containsFold(got.Message, "3 timed out") {
+		t.Fatalf("message = %q", got.Message)
+	}
+	if !containsFold(got.Hint, "increase the timeout") {
+		t.Fatalf("hint = %q", got.Hint)
+	}
+}

--- a/internal/cli/bench.go
+++ b/internal/cli/bench.go
@@ -24,6 +24,9 @@ func RunBench(config *BenchConfig) error {
 		Headers: config.Headers,
 		Body:    config.Body,
 	}
+	if err := req.Validate(); err != nil {
+		return err
+	}
 
 	jobConfig := &http.JobConfig{
 		Request:          req,

--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/owenHochwald/Volt/internal/apperror"
 )
 
 const (
@@ -56,7 +58,8 @@ func (c *Client) Send(req *Request, result chan<- *Response) {
 
 	res, err := c.makeCustomRequest(req)
 	if err != nil {
-		result <- &Response{Error: err.Error()}
+		failure := apperror.FromNetwork(err)
+		result <- &Response{Error: failure.Message, Failure: failure}
 		return
 	}
 
@@ -69,7 +72,8 @@ func (c *Client) Send(req *Request, result chan<- *Response) {
 	defer res.Body.Close()
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
-		result <- &Response{Error: err.Error()}
+		failure := apperror.FromNetwork(err)
+		result <- &Response{Error: failure.Message, Failure: failure}
 		return
 	}
 

--- a/internal/http/client_test.go
+++ b/internal/http/client_test.go
@@ -5,7 +5,8 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
-	//http2 "github.com/owenHochwald/Volt/internal/http"
+
+	"github.com/owenHochwald/Volt/internal/apperror"
 )
 
 func TestClient_Send(t *testing.T) {
@@ -86,6 +87,12 @@ func TestClient_Send(t *testing.T) {
 			if tt.wantErr {
 				if result.Error == "" {
 					t.Fatalf("expected error, got nil")
+				}
+				if result.Failure == nil || result.Failure.Category != apperror.Network || result.Failure.Code != apperror.Timeout {
+					t.Fatalf("failure = %#v, want a timeout network error", result.Failure)
+				}
+				if result.Failure.Hint == "" {
+					t.Fatal("timeout failure did not include a recovery hint")
 				}
 				return
 			}

--- a/internal/http/request.go
+++ b/internal/http/request.go
@@ -1,9 +1,12 @@
 package http
 
 import (
-	"fmt"
+	"encoding/json"
+	"net/url"
 	"slices"
 	"strings"
+
+	"github.com/owenHochwald/Volt/internal/apperror"
 )
 
 const (
@@ -65,29 +68,42 @@ func NewRequestWithParams(method, url string) *Request {
 
 func (r *Request) Validate() error {
 	if r.Name != "" && len(r.Name) > 40 {
-		return fmt.Errorf("name too long: %s", r.Name)
+		return apperror.ValidationError(apperror.InvalidConfig, "The request name is too long.", "Use a name with 40 characters or fewer.")
 	}
 	if r.Method == "" {
-		return fmt.Errorf("method is required")
+		return apperror.ValidationError(apperror.InvalidConfig, "Choose an HTTP method.", "Press ? to see the available request controls.")
 	}
 	if r.URL == "" {
-		return fmt.Errorf("url is required")
+		return apperror.InvalidURL(r.URL)
 	}
 
 	if !slices.Contains(validMethods, r.Method) {
-		return fmt.Errorf("invalid method: %s", r.Method)
+		return apperror.ValidationError(apperror.InvalidConfig, "The HTTP method is not supported.", "Choose GET, POST, PUT, PATCH, or DELETE.")
 	}
 
-	if !strings.HasPrefix(r.URL, "http://") && !strings.HasPrefix(r.URL, "https://") {
-		return fmt.Errorf("invalid url: %s", r.URL)
+	parsedURL, err := url.Parse(r.URL)
+	if err != nil || (parsedURL.Scheme != "http" && parsedURL.Scheme != "https") || parsedURL.Host == "" {
+		return apperror.InvalidURL(r.URL)
 	}
 
 	if r.Headers != nil && len(r.Headers) > 100 {
-		return fmt.Errorf("too many headers: %d", len(r.Headers))
+		return apperror.ValidationError(apperror.InvalidHeaders, "There are too many request headers.", "Use 100 headers or fewer.")
 	}
 	if r.Body != "" && len(r.Body) > 10000 {
-		return fmt.Errorf("body too long: %d", len(r.Body))
+		return apperror.ValidationError(apperror.InvalidConfig, "The request body is too long.", "Use a body with 10,000 characters or fewer.")
+	}
+	if r.Body != "" && isJSONRequest(r.Headers) && !json.Valid([]byte(r.Body)) {
+		return apperror.ValidationError(apperror.InvalidJSON, "The JSON request body is not valid.", "Fix the JSON syntax, then try again.")
 	}
 
 	return nil
+}
+
+func isJSONRequest(headers map[string]string) bool {
+	for key, value := range headers {
+		if strings.EqualFold(key, "Content-Type") && strings.Contains(strings.ToLower(value), "application/json") {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/http/request_test.go
+++ b/internal/http/request_test.go
@@ -2,6 +2,8 @@ package http
 
 import (
 	"testing"
+
+	"github.com/owenHochwald/Volt/internal/apperror"
 )
 
 func TestRequest_Validate(t *testing.T) {
@@ -45,5 +47,26 @@ func TestRequest_Validate(t *testing.T) {
 				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestRequestValidateRejectsMalformedJSON(t *testing.T) {
+	request := &Request{
+		Method:  POST,
+		URL:     "https://example.com",
+		Headers: map[string]string{"content-type": "application/json; charset=utf-8"},
+		Body:    `{"unfinished":`,
+	}
+
+	err := request.Validate()
+	failure, ok := err.(*apperror.Error)
+	if !ok {
+		t.Fatalf("error = %T, want *apperror.Error", err)
+	}
+	if failure.Category != apperror.Validation || failure.Code != apperror.InvalidJSON {
+		t.Fatalf("error = (%s, %s), want (%s, %s)", failure.Category, failure.Code, apperror.Validation, apperror.InvalidJSON)
+	}
+	if failure.Hint != "Fix the JSON syntax, then try again." {
+		t.Fatalf("hint = %q", failure.Hint)
 	}
 }

--- a/internal/http/requester.go
+++ b/internal/http/requester.go
@@ -6,13 +6,13 @@ package http
 
 import (
 	"context"
-	"errors"
 	"math"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/influxdata/tdigest"
+	"github.com/owenHochwald/Volt/internal/apperror"
 	"github.com/valyala/fasthttp"
 )
 
@@ -115,18 +115,20 @@ func (s *LoadTestStats) MeanDuration() time.Duration {
 // requestBatch is pooled and passed by pointer so the hot path does not
 // allocate for every request or copy latency arrays through the channel.
 type requestBatch struct {
-	count         int
-	failures      int
-	timeoutErrs   int
-	transportErrs int
-	canceledErrs  int
-	bytesSent     int64
-	bytesRecv     int64
-	total         time.Duration
-	min           time.Duration
-	max           time.Duration
-	latencies     [statsBatchSize]time.Duration
-	statuses      [statsBatchSize]uint16
+	count                 int
+	failures              int
+	timeoutErrs           int
+	dnsErrs               int
+	connectionRefusedErrs int
+	transportErrs         int
+	canceledErrs          int
+	bytesSent             int64
+	bytesRecv             int64
+	total                 time.Duration
+	min                   time.Duration
+	max                   time.Duration
+	latencies             [statsBatchSize]time.Duration
+	statuses              [statsBatchSize]uint16
 }
 
 func (b *requestBatch) reset() {
@@ -384,10 +386,17 @@ func (r *runState) runWorker(ctx context.Context, wg *sync.WaitGroup) {
 			batch.failures++
 			if ctx.Err() != nil {
 				batch.canceledErrs++
-			} else if isTimeoutError(err) {
-				batch.timeoutErrs++
 			} else {
-				batch.transportErrs++
+				switch apperror.FromNetwork(err).Code {
+				case apperror.Timeout:
+					batch.timeoutErrs++
+				case apperror.DNS:
+					batch.dnsErrs++
+				case apperror.ConnectionRefused:
+					batch.connectionRefusedErrs++
+				default:
+					batch.transportErrs++
+				}
 			}
 		} else if status >= 400 {
 			batch.failures++
@@ -404,15 +413,6 @@ func (r *runState) runWorker(ctx context.Context, wg *sync.WaitGroup) {
 	} else {
 		r.releaseBatch(batch)
 	}
-}
-
-func isTimeoutError(err error) bool {
-	if errors.Is(err, fasthttp.ErrTimeout) {
-		return true
-	}
-	type timeout interface{ Timeout() bool }
-	var timeoutErr timeout
-	return errors.As(err, &timeoutErr) && timeoutErr.Timeout()
 }
 
 func (r *runState) acquireBatch() *requestBatch {
@@ -501,10 +501,16 @@ func (r *runState) mergeBatch(batch *requestBatch) {
 	}
 
 	if batch.timeoutErrs > 0 {
-		r.stats.Errors["timeout"] += int64(batch.timeoutErrs)
+		r.stats.Errors[string(apperror.Timeout)] += int64(batch.timeoutErrs)
+	}
+	if batch.dnsErrs > 0 {
+		r.stats.Errors[string(apperror.DNS)] += int64(batch.dnsErrs)
+	}
+	if batch.connectionRefusedErrs > 0 {
+		r.stats.Errors[string(apperror.ConnectionRefused)] += int64(batch.connectionRefusedErrs)
 	}
 	if batch.transportErrs > 0 {
-		r.stats.Errors["transport"] += int64(batch.transportErrs)
+		r.stats.Errors[string(apperror.Transport)] += int64(batch.transportErrs)
 	}
 	if batch.canceledErrs > 0 {
 		r.stats.Errors["canceled"] += int64(batch.canceledErrs)

--- a/internal/http/requester_test.go
+++ b/internal/http/requester_test.go
@@ -248,7 +248,7 @@ func TestHTTPFailuresAndStatusCodesAreClassified(t *testing.T) {
 }
 
 func TestTransportAndTimeoutErrorsAreClassified(t *testing.T) {
-	t.Run("transport", func(t *testing.T) {
+	t.Run("connection refused", func(t *testing.T) {
 		listener, err := net.Listen("tcp", "127.0.0.1:0")
 		require.NoError(t, err)
 		url := "http://" + listener.Addr().String()
@@ -262,7 +262,7 @@ func TestTransportAndTimeoutErrorsAreClassified(t *testing.T) {
 		})
 		assert.Equal(t, 1, stats.CompletedRequests)
 		assert.Equal(t, 1, stats.FailedRequests)
-		assert.Equal(t, int64(1), stats.Errors["transport"])
+		assert.Equal(t, int64(1), stats.Errors["connection_refused"])
 	})
 
 	t.Run("timeout", func(t *testing.T) {

--- a/internal/http/response.go
+++ b/internal/http/response.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/owenHochwald/Volt/internal/apperror"
 )
 
 type ResultMsg struct {
@@ -11,6 +13,9 @@ type ResultMsg struct {
 }
 
 func (r *ResultMsg) String() string {
+	if r == nil || r.Response == nil {
+		return "empty response"
+	}
 	if r.Response.Error != "" {
 		// TODO: add styles
 		return r.Response.Error
@@ -23,11 +28,12 @@ func (r *Response) ParseContentType() string {
 }
 
 type Response struct {
-	StatusCode int           `json:"status_code"`
-	Status     string        `json:"status,omitempty"`
-	Headers    http.Header   `json:"headers,omitempty"`
-	Body       string        `json:"body,omitempty"`
-	Duration   time.Duration `json:"duration,omitempty"`
-	Error      string        `json:"error,omitempty"`
-	RoundTrip  bool          `json:"round_trip,omitempty"`
+	StatusCode int             `json:"status_code"`
+	Status     string          `json:"status,omitempty"`
+	Headers    http.Header     `json:"headers,omitempty"`
+	Body       string          `json:"body,omitempty"`
+	Duration   time.Duration   `json:"duration,omitempty"`
+	Error      string          `json:"error,omitempty"`
+	RoundTrip  bool            `json:"round_trip,omitempty"`
+	Failure    *apperror.Error `json:"-"`
 }

--- a/internal/storage/sqlite_storage.go
+++ b/internal/storage/sqlite_storage.go
@@ -39,6 +39,7 @@ func deserializeHeaders(jsonStr string) (map[string]string, error) {
 func runMigrations(db *sql.DB) error {
 	// Set the embedded filesystem for goose
 	goose.SetBaseFS(embedMigrations)
+	goose.SetLogger(goose.NopLogger())
 
 	if err := goose.SetDialect("sqlite3"); err != nil {
 		return err

--- a/internal/storage/sqlite_storage_test.go
+++ b/internal/storage/sqlite_storage_test.go
@@ -1,13 +1,44 @@
 package storage
 
 import (
+	"bytes"
+	"fmt"
 	"testing"
 
 	_ "modernc.org/sqlite"
 
 	"github.com/alecthomas/assert/v2"
 	"github.com/owenHochwald/Volt/internal/http"
+	"github.com/pressly/goose/v3"
 )
+
+type recordingGooseLogger struct {
+	output *bytes.Buffer
+}
+
+func (l recordingGooseLogger) Printf(format string, values ...interface{}) {
+	_, _ = fmt.Fprintf(l.output, format, values...)
+}
+
+func (l recordingGooseLogger) Fatalf(format string, values ...interface{}) {
+	_, _ = fmt.Fprintf(l.output, format, values...)
+}
+
+func TestNewSQLiteStorageSilencesMigrationLogs(t *testing.T) {
+	var output bytes.Buffer
+	goose.SetLogger(recordingGooseLogger{output: &output})
+	t.Cleanup(func() { goose.SetLogger(goose.NopLogger()) })
+
+	store, err := NewSQLiteStorage(t.TempDir() + "/volt.db")
+	if err != nil {
+		t.Fatalf("create storage: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	if output.Len() != 0 {
+		t.Fatalf("migration logging was not silenced: %q", output.String())
+	}
+}
 
 func setupTestDB(t *testing.T) *SQLiteStorage {
 	t.Helper()

--- a/internal/ui/notification.go
+++ b/internal/ui/notification.go
@@ -5,6 +5,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/owenHochwald/Volt/internal/apperror"
 )
 
 type NotificationLevel string
@@ -19,6 +20,7 @@ const (
 type Notification struct {
 	Level NotificationLevel
 	Text  string
+	Hint  string
 }
 
 type NotificationMsg struct {
@@ -33,6 +35,19 @@ func NotifyCmd(level NotificationLevel, text string) tea.Cmd {
 				Text:  text,
 			},
 		}
+	}
+}
+
+func ErrorNotification(err *apperror.Error) Notification {
+	if err == nil {
+		err = apperror.ApplicationError()
+	}
+	return Notification{Level: NotificationError, Text: err.Message, Hint: err.Hint}
+}
+
+func NotifyErrorCmd(err *apperror.Error) tea.Cmd {
+	return func() tea.Msg {
+		return NotificationMsg{Notification: ErrorNotification(err)}
 	}
 }
 
@@ -54,6 +69,10 @@ func (n Notification) View(width int) string {
 
 	prefix := lipgloss.NewStyle().Bold(true).Foreground(color).Render(" " + label + " ")
 	content := lipgloss.JoinHorizontal(lipgloss.Left, prefix, " ", n.Text)
+	if strings.TrimSpace(n.Hint) != "" {
+		hint := lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Render(" · " + n.Hint)
+		content = lipgloss.JoinHorizontal(lipgloss.Left, content, hint)
+	}
 	return lipgloss.NewStyle().
 		Width(max(width, 1)).
 		MaxWidth(max(width, 1)).

--- a/internal/ui/requestpane/mode_loadtest.go
+++ b/internal/ui/requestpane/mode_loadtest.go
@@ -2,6 +2,7 @@ package requestpane
 
 import (
 	tea "charm.land/bubbletea/v2"
+	"github.com/owenHochwald/Volt/internal/apperror"
 	"github.com/owenHochwald/Volt/internal/ui"
 	"github.com/owenHochwald/Volt/internal/ui/keybindings"
 )
@@ -87,7 +88,7 @@ func (ltm *LoadTestMode) handleSubmit(m *RequestPane, msg tea.KeyPressMsg) (*Req
 		if err != nil {
 			m.ParseErrors = append(m.ParseErrors, "Load test config error: "+err.Error())
 			m.RequestInProgress = false
-			return m, ui.NotifyCmd(ui.NotificationError, err.Error())
+			return m, ui.NotifyErrorCmd(apperror.FromApplication(err))
 		}
 		return m, ui.StartLoadTestCmd(config)
 	}

--- a/internal/ui/requestpane/mode_normal.go
+++ b/internal/ui/requestpane/mode_normal.go
@@ -2,6 +2,7 @@ package requestpane
 
 import (
 	tea "charm.land/bubbletea/v2"
+	"github.com/owenHochwald/Volt/internal/apperror"
 	"github.com/owenHochwald/Volt/internal/ui"
 	"github.com/owenHochwald/Volt/internal/ui/keybindings"
 )
@@ -64,7 +65,7 @@ func (nm *NormalMode) handleSubmit(m *RequestPane, msg tea.KeyPressMsg) (*Reques
 		m.syncRequest()
 		if err := m.validateRequest(); err != nil {
 			m.RequestInProgress = false
-			return m, ui.NotifyCmd(ui.NotificationError, err.Error())
+			return m, ui.NotifyErrorCmd(apperror.FromApplication(err))
 		}
 		m.RequestInProgress = true
 

--- a/internal/ui/requestpane/sync.go
+++ b/internal/ui/requestpane/sync.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/owenHochwald/Volt/internal/apperror"
 	"github.com/owenHochwald/Volt/internal/http"
 	"github.com/owenHochwald/Volt/internal/utils"
 )
@@ -28,10 +29,14 @@ func (m *RequestPane) syncRequest() {
 
 func (m *RequestPane) validateRequest() error {
 	if len(m.ParseErrors) > 0 {
-		return fmt.Errorf("invalid headers: %s", strings.Join(m.ParseErrors, "; "))
+		return apperror.ValidationError(
+			apperror.InvalidHeaders,
+			"The request headers are not valid.",
+			"Use one Header-Name: value pair per line, then try again.",
+		)
 	}
 	if err := m.Request.Validate(); err != nil {
-		return fmt.Errorf("invalid request: %w", err)
+		return err
 	}
 	return nil
 }
@@ -84,7 +89,11 @@ func (m *RequestPane) buildJobConfig() (*http.JobConfig, error) {
 	m.ParseErrors = append(m.ParseErrors, parseErrors...)
 
 	if len(parseErrors) > 0 {
-		return nil, fmt.Errorf("invalid load test configuration: %s", strings.Join(parseErrors, "; "))
+		return nil, apperror.ValidationError(
+			apperror.InvalidConfig,
+			"Load test configuration is not valid: "+strings.Join(parseErrors, "; "),
+			"Fix the settings and try again. Press ? to see keybindings.",
+		)
 	}
 	if err := m.validateRequest(); err != nil {
 		return nil, err

--- a/internal/ui/requestpane/update.go
+++ b/internal/ui/requestpane/update.go
@@ -2,6 +2,7 @@ package requestpane
 
 import (
 	tea "charm.land/bubbletea/v2"
+	"github.com/owenHochwald/Volt/internal/apperror"
 	"github.com/owenHochwald/Volt/internal/http"
 	"github.com/owenHochwald/Volt/internal/ui"
 	"github.com/owenHochwald/Volt/internal/ui/keybindings"
@@ -31,7 +32,7 @@ func (m RequestPane) Update(msg tea.Msg) (RequestPane, tea.Cmd) {
 		if keybindings.Matches(msg, m.keys.SaveRequest) {
 			m.syncRequest()
 			if err := m.validateRequest(); err != nil {
-				return m, ui.NotifyCmd(ui.NotificationError, err.Error())
+				return m, ui.NotifyErrorCmd(apperror.FromApplication(err))
 			}
 			return m, ui.SaveRequestCmd(m.DB, m.Request)
 		}

--- a/internal/ui/requestpane/update_test.go
+++ b/internal/ui/requestpane/update_test.go
@@ -189,6 +189,9 @@ func TestInvalidHeadersBlockSubmissionAndSurfaceError(t *testing.T) {
 	if !strings.Contains(strings.ToLower(msg.Notification.Text), "header") {
 		t.Fatalf("notification = %q, want header error", msg.Notification.Text)
 	}
+	if !strings.Contains(strings.ToLower(msg.Notification.Hint), "one header-name") {
+		t.Fatalf("notification hint = %q, want header recovery guidance", msg.Notification.Hint)
+	}
 }
 
 func TestInvalidLoadTestConfigBlocksStartAndSurfacesError(t *testing.T) {
@@ -212,6 +215,28 @@ func TestInvalidLoadTestConfigBlocksStartAndSurfacesError(t *testing.T) {
 	}
 	if !strings.Contains(strings.ToLower(msg.Notification.Text), "concurrency") {
 		t.Fatalf("notification = %q, want concurrency error", msg.Notification.Text)
+	}
+	if !strings.Contains(msg.Notification.Hint, "?") {
+		t.Fatalf("notification hint = %q, want keybinding guidance", msg.Notification.Hint)
+	}
+}
+
+func TestInvalidURLOffersLikelyCorrection(t *testing.T) {
+	pane := newTestRequestPane(t)
+	pane.SetFocused(true)
+	pane.URLInput.SetValue("example.com/health")
+
+	updated, cmd := pane.Update(keyPress(tea.KeyEnter, "", tea.ModAlt))
+
+	if updated.RequestInProgress {
+		t.Fatal("invalid URL started a request")
+	}
+	msg, ok := cmd().(ui.NotificationMsg)
+	if !ok {
+		t.Fatalf("message type = %T, want ui.NotificationMsg", cmd())
+	}
+	if !strings.Contains(msg.Notification.Hint, "https://example.com/health") {
+		t.Fatalf("notification hint = %q, want URL correction", msg.Notification.Hint)
 	}
 }
 

--- a/internal/ui/responsepane/loadtest_render_test.go
+++ b/internal/ui/responsepane/loadtest_render_test.go
@@ -36,8 +36,8 @@ func TestLoadTestErrorsIncludeSortedStatusBreakdown(t *testing.T) {
 		"204",
 		"400",
 		"503",
-		"http_4xx",
-		"http_5xx",
+		"HTTP 4xx responses",
+		"HTTP 5xx responses",
 	} {
 		if !strings.Contains(rendered, expected) {
 			t.Errorf("error view does not contain %q:\n%s", expected, rendered)

--- a/internal/ui/responsepane/renderer_loadtest.go
+++ b/internal/ui/responsepane/renderer_loadtest.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/owenHochwald/Volt/internal/apperror"
 )
 
 // renderLoadTestOverview renders the overview tab for load test results
@@ -141,7 +143,7 @@ func (m ResponsePane) renderLoadTestErrors() string {
 		}
 		sort.Strings(classes)
 		for _, class := range classes {
-			b.WriteString(responseKeyStyle.Render(class))
+			b.WriteString(responseKeyStyle.Render(apperror.ErrorClassLabel(class)))
 			b.WriteString(": ")
 			b.WriteString(responseValueStyle.Render(fmt.Sprintf("%d occurrences", stats.Errors[class])))
 			b.WriteString("\n\n")


### PR DESCRIPTION
## Summary
- add centralized network, validation, storage, and application error types with concise recovery hints
- present friendly HTTP, storage, validation, and load-test errors in the status notification area and response/load-test views
- classify timeouts, DNS failures, connection refusals, and HTTP failures; validate malformed JSON request bodies; recover UI update panics without stack details

## Tests
- go test ./...
- go vet ./...
- go test -race ./internal/apperror ./internal/http (passed before remaining race-package compilation ran out of disk space)